### PR TITLE
Fix lint in Readme.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ class HomeResource extends Drash.Http.Resource {
   }
 }
 
-let server = new Drash.Http.Server({
+const server = new Drash.Http.Server({
   address: "localhost:1337",
   response_output: "text/html",
   resources: [HomeResource]


### PR DESCRIPTION
As `server` is not meant to be mutated, it would be better to set it as a const.