### PR TITLE
Added Cookie handling

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -33,3 +33,10 @@ export {
 export {
   MultipartReader, FormFile
 } from "https://deno.land/std@v0.34.0/mime/multipart.ts";
+
+export { 
+  getCookies,
+  setCookie,
+  delCookie,
+  Cookie
+} from "https://deno.land/std/http/cookie.ts"

--- a/deps.ts
+++ b/deps.ts
@@ -39,4 +39,4 @@ export {
   setCookie,
   delCookie,
   Cookie
-} from "https://deno.land/std/http/cookie.ts"
+} from "https://deno.land/std@v0.34.0/http/cookie.ts"

--- a/example_app/app_server.ts
+++ b/example_app/app_server.ts
@@ -3,6 +3,7 @@ import FilesResource from "./files_resource.ts";
 import HomeResource from "./home_resource.ts";
 import UsersResource from "./users_resource.ts";
 import CoffeeResource from "./coffee_resource.ts";
+import CookieResource from "./cookie_resource.ts";
 
 let server = new Drash.Http.Server({
   address: "localhost:1447",
@@ -10,7 +11,7 @@ let server = new Drash.Http.Server({
   memory_allocation: {
     multipart_form_data: 128
   },
-  resources: [CoffeeResource, FilesResource, HomeResource, UsersResource]
+  resources: [CoffeeResource, FilesResource, HomeResource, UsersResource, CookieResource]
 });
 
 export default server;

--- a/example_app/app_test.ts
+++ b/example_app/app_test.ts
@@ -28,6 +28,7 @@ members.test("HomeResource", async () => {
 
   response = await members.fetch.patch("http://localhost:1667");
   members.assert.equals(await response.text(), '"Method Not Allowed"');
+  
 });
 
 members.test("UsersResource", async () => {
@@ -164,6 +165,44 @@ members.test("CoffeeResource", async () => {
   // });
   // members.assert.equals(await response.text(), "{\"name\":\"Medium\"}");
 });
+
+members.test("CookieResource", async () => {
+  let response;
+  let cookies;
+  let cookieName;
+  let cookieVal;
+
+  const cookie = { name: 'testCookie', value: 'Drash' }
+
+  // Post
+  response = await members.fetch.post("http://localhost:1667/cookie", {
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: cookie
+  });
+  members.assert.equals(await response.text(), "\"Saved your cookie!\"")
+
+  // Get - relies on POST saving a cookie
+  response = await members.fetch.get("http://localhost:1667/cookie", {
+    credentials: 'same-origin',
+  });
+  cookies = response.headers.get('set-cookie') || ''
+  cookieName = cookies.split(';')[0].split('=')[0]
+  cookieVal = cookies.split(';')[0].split('=')[1]
+  members.assert.equals(cookieName, cookie.name)
+  members.assert.equals(cookieVal, cookie.value)
+
+  // Remove
+  response = await members.fetch.delete("http://localhost:1667/cookie", {
+    method: 'DELETE'
+  });
+  cookies = response.headers.get('set-cookie') || ''
+  cookieName = cookies.split(';')[0].split('=')[0]
+  cookieVal = cookies.split(';')[0].split('=')[1]
+  members.assert.equals(cookieVal, '')
+  
+})
 
 // members.test("FilesResource", async () => {
 //   let response;

--- a/example_app/app_test.ts
+++ b/example_app/app_test.ts
@@ -183,17 +183,16 @@ members.test("CookieResource", async () => {
   });
   members.assert.equals(await response.text(), "\"Saved your cookie!\"")
 
-  // Get - relies on POST saving a cookie
+  // Get - Dependent on the above post request saving a cookie
   response = await members.fetch.get("http://localhost:1667/cookie", {
     credentials: 'same-origin',
+    headers: {
+      'Cookie': 'testCookie=Drash'
+    }
   });
-  cookies = response.headers.get('set-cookie') || ''
-  cookieName = cookies.split(';')[0].split('=')[0]
-  cookieVal = cookies.split(';')[0].split('=')[1]
-  members.assert.equals(cookieName, cookie.name)
-  members.assert.equals(cookieVal, cookie.value)
+  members.assert.equals(await response.text(), "\"Drash\"")
 
-  // Remove
+  // Remove - Dependent on the above post request saving a cookie
   response = await members.fetch.delete("http://localhost:1667/cookie", {
     method: 'DELETE'
   });

--- a/example_app/cookie_resource.ts
+++ b/example_app/cookie_resource.ts
@@ -1,0 +1,28 @@
+import Drash from "../mod.ts";
+
+export default class HomeResource extends Drash.Http.Resource {
+  static paths = ["/cookie", "/cookie/"];
+
+  public GET() {
+    this.response.body = "GET request received!";
+    this.response.setCookie({name: 'testCookie', value: 'Drash'})
+    return this.response;
+  }
+
+  public POST () {
+    const cookie = this.request.getBodyParam('name')
+    this.response.body = "Saved your cookie!";
+    return this.response;
+  }
+
+  public PUT() {
+    this.response.body = "PUT request received!";
+    return this.response;
+  }
+
+  public DELETE() {
+    this.response.body = "DELETE request received!";
+    this.response.delCookie('testCookie')
+    return this.response;
+  }
+}

--- a/example_app/cookie_resource.ts
+++ b/example_app/cookie_resource.ts
@@ -4,13 +4,13 @@ export default class CookieResource extends Drash.Http.Resource {
   static paths = ["/cookie", "/cookie/"];
 
   public GET() {
-    this.response.body = "GET request received!";
-    this.response.setCookie({name: 'testCookie', value: 'Drash'})
-    return this.response;
+    const cookieValue = this.request.getCookie('testCookie')
+    this.response.body = cookieValue
+    return this.response
   }
 
   public POST () {
-    const cookie = this.request.getBodyParam('name')
+    this.response.setCookie({ name: 'testCookie', value: 'Drash' })
     this.response.body = "Saved your cookie!";
     return this.response;
   }

--- a/example_app/cookie_resource.ts
+++ b/example_app/cookie_resource.ts
@@ -1,6 +1,6 @@
 import Drash from "../mod.ts";
 
-export default class HomeResource extends Drash.Http.Resource {
+export default class CookieResource extends Drash.Http.Resource {
   static paths = ["/cookie", "/cookie/"];
 
   public GET() {

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -1,5 +1,6 @@
 import Drash from "../../mod.ts";
 import { STATUS_TEXT, Status } from "../../deps.ts";
+import { setCookie, delCookie, Cookie } from "../../deps.ts"
 
 /**
  * @memberof Drash.Http
@@ -58,6 +59,34 @@ export default class Response {
   }
 
   // FILE MARKER: METHODS - PUBLIC /////////////////////////////////////////////
+
+  /**
+   * @description
+   *     Create a cookie to be sent in the response.
+   *     Note: Once set, it cannot be read until the next
+   *     request
+   * 
+   * @param Cookie cookie
+   *     Object holding all the properties for a cookie object
+   * 
+   * @return void
+   */
+  public setCookie(cookie: Cookie): void {
+    setCookie(this, cookie)
+  }
+
+  /**
+   * @description
+   *     Delete a cookie before sending a response
+   * 
+   * @param string cookieName 
+   *     The cookie name to delete
+   * 
+   * @return void
+   */
+  public delCookie (cookieName: string): void {
+    delCookie(this, cookieName)
+  }
 
   /**
    * @description

--- a/src/services/http_request_service.ts
+++ b/src/services/http_request_service.ts
@@ -6,6 +6,7 @@ import {
 } from "../../deps.ts";
 import StringService from "./string_service.ts";
 import { ParsedRequestBody } from "../interfaces/parsed_request_body.ts";
+import { getCookies, Cookie } from "../../deps.ts"
 type Reader = Deno.Reader;
 const decoder = new TextDecoder();
 const encoder = new TextEncoder();
@@ -27,6 +28,22 @@ export default class HttpRequestService {
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - PUBLIC //////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @description
+   *     Get a cookie value by the name that is sent in with the request
+   * 
+   * @param string cookie
+   *     The name of the cookie to retrieve
+   * 
+   * @return string
+   *     The cookie value associated with the cookie name or undefined
+   *     if a cookie with that name doesn't exist
+   */
+  public getCookie (request: any, name: string): string {
+    const cookies: { [key: string]: string } = getCookies(request)
+    return cookies[name]
+  }
 
   /**
    * @description
@@ -289,6 +306,9 @@ export default class HttpRequestService {
     };
     request.getUrlQueryParam = function getRequestUrlQueryParam(input: string) {
       return t.getRequestUrlQueryParam(request, input);
+    };
+    request.getCookie = function getCookie (name: string) {
+      return t.getCookie(request, name);
     };
 
     return request;


### PR DESCRIPTION
Implements #143 

I will make a pr to deno-drash docs once this PR is approved in case someone wants me to adjust something which could lead to a doc block change.

**Developments**
Added the ability to get a cookie, set a cookie and delete a cookie. This functionality is about 95% Deno, utilising their cookie module. It conforms to the standards e.g. include `path`, `expiry` etc.

The get cookie function resides inside the request object, and will use Deno's `getCookies` to retrieve a single cookie, as there isn't an already built function to get a single one.

The delete cookie and set cookie functions reside inside the response class. The reason why these functions are re-defined is so it can allow type hints whilst writing the code as simply doing `public setCookie = setCookie` threw no errors when passing in 0 params, so they were changed to the following:
```
// so it can be strict
public setCookie (cookie: Cookie) { setCookie(this, cookie) }
```

**How to Use**
To get cookies:
`const carCookieValue = this.request.getCookie('car')`

To set cookies:
```
const cookie: Cookie = {
  name: 'car',
  value: 'Ford',
  expiry: 'some date'
  ...
}
this.response.setCookie(cookie)
```

To delete a cookie:
`this.response.delCookie('car')`

**Resources**
Deno's cookie module (holds interface for Cookie as well): https://deno.land/std/http/cookie.ts