### PR TITLE
[issue-#159-pretty-links] add pretty links

### DIFF
--- a/example_app/app_server.ts
+++ b/example_app/app_server.ts
@@ -11,6 +11,7 @@ import Middleware from "./middleware.ts";
 
 let server = new Drash.Http.Server({
   address: "localhost:1447",
+  directory: Deno.realpathSync("./"),
   response_output: "application/json",
   middleware: {
     resource_level: [
@@ -20,6 +21,7 @@ let server = new Drash.Http.Server({
   memory_allocation: {
     multipart_form_data: 128,
   },
+  pretty_links: true,
   resources: [
     CoffeeResource,
     CookieResource,
@@ -28,6 +30,7 @@ let server = new Drash.Http.Server({
     MiddlewareResource,
     UsersResource,
   ],
+  static_paths: ["/public"]
 });
 
 export default server;

--- a/example_app/public/pretty/index.html
+++ b/example_app/public/pretty/index.html
@@ -1,0 +1,1 @@
+Pretty links!

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -104,6 +104,7 @@ export default class Response {
       case "text/html":
       case "text/xml":
       case "text/plain":
+      default:
         return this.body;
 
     }
@@ -168,12 +169,12 @@ export default class Response {
    *     Send the response of a static asset (e.g., a CSS file, JS file, PDF
    *     file, etc.) to the client making the request.
    *
-   * @param string file
+   * @param null|string file
    *     The file that will be served to the client.
    *
    * @return {status: number, headers: Headers, body: any}
    */
-  public sendStatic(file: string): {
+  public sendStatic(file: null|string, contents: null|Uint8Array = null): {
     status: number;
     headers: Headers;
     body: any;
@@ -181,7 +182,7 @@ export default class Response {
     let output = {
       status: this.status_code,
       headers: this.headers,
-      body: Deno.readFileSync(file),
+      body: file ? Deno.readFileSync(file) : contents,
     };
 
     this.request.respond(output);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -386,6 +386,15 @@ export default class Server {
   public handleHttpRequestForStaticPathAsset(request: any): any {
     try {
       let response = new Drash.Http.Response(request);
+      if (this.configs.pretty_links) {
+        let extension = request.url_path.split(".")[1];
+        if (!extension) {
+          let contents = Deno.readFileSync(this.directory + "/" + request.url_path + "/index.html");
+          if (contents) {
+            return response.sendStatic(null, contents);
+          }
+        }
+      }
       return response.sendStatic(this.directory + "/" + request.url_path);
     } catch (error) {
       return this.handleHttpRequestError(request, this.httpErrorResponse(404));

--- a/src/interfaces/server_configs.ts
+++ b/src/interfaces/server_configs.ts
@@ -44,6 +44,13 @@ import Drash from "../../mod.ts";
  *               server_level: { ... }
  *             }
  *
+ *     pretty_links?: boolean
+ *
+ *         Enabling pretty links allows your Drash server to check whether or
+ *         not an index.html file exists in a static directory. For example, if
+ *         /public/app/index.html exists, then you can go to /public/app and it
+ *         will serve the index.html in that static directory.
+ *
  *     resources: any
  *
  *         An array of resources that the server should register. Passing in 0
@@ -71,7 +78,7 @@ export interface ServerConfigs {
   logger?: Drash.CoreLoggers.ConsoleLogger | Drash.CoreLoggers.FileLogger;
   memory_allocation?: { multipart_form_data?: number };
   middleware?: any;
-  pretty_links: boolean;
+  pretty_links?: boolean;
   resources: any;
   response_output?: string;
   static_paths?: string[];

--- a/src/interfaces/server_configs.ts
+++ b/src/interfaces/server_configs.ts
@@ -71,6 +71,7 @@ export interface ServerConfigs {
   logger?: Drash.CoreLoggers.ConsoleLogger | Drash.CoreLoggers.FileLogger;
   memory_allocation?: { multipart_form_data?: number };
   middleware?: any;
+  pretty_links: boolean;
   resources: any;
   response_output?: string;
   static_paths?: string[];


### PR DESCRIPTION
To test:

1. `cd example_app`
2. `deno --allow-all app.ts`
3. Go to `localhost:1447`
4. Go to `localhost:1447/public/pretty`
5. Go to `localhost:1447/public/pretty/index.html`