### PR TITLE
Issue #175 support deno doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ```typescript
 // File: app.ts
 
-import Drash from "https://deno.land/x/drash@v0.39.5/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v0.39.5/mod.ts";
 
 class HomeResource extends Drash.Http.Resource {
   static paths = ["/"];

--- a/console/tests
+++ b/console/tests
@@ -3,9 +3,9 @@
 (
   export DRASH_PROCESS="test"
   export DRASH_ROOT_DIR=$PWD
-  deno --allow-net --allow-read --allow-write --allow-env tests/test.ts
-  cd example_app
-  deno --allow-net --allow-read --allow-write --allow-env app_test.ts
-  deno --allow-net --allow-read --allow-write --allow-env app_two_test.ts
-  cd -
+  deno --allow-net --allow-read --allow-write --allow-env tests/test.ts \
+  && cd example_app \
+  && deno --allow-net --allow-read --allow-write --allow-env app_test.ts \
+  && deno --allow-net --allow-read --allow-write --allow-env app_two_test.ts \
+  && cd -
 )

--- a/console/tests
+++ b/console/tests
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 (
+  export DRASH_PROCESS="test"
   export DRASH_ROOT_DIR=$PWD
   deno --allow-net --allow-read --allow-write --allow-env tests/test.ts
+  cd example_app
+  deno --allow-net --allow-read --allow-write --allow-env app_test.ts
+  deno --allow-net --allow-read --allow-write --allow-env app_two_test.ts
+  cd -
 )

--- a/mod.ts
+++ b/mod.ts
@@ -47,7 +47,7 @@ import * as util_members from "./src/util/members.ts";
 // Usage: import Drash from "/path/to/drash/mod.ts";
 //
 
-namespace Drash {
+export declare namespace Drash {
   // TODO: Remove this when the docs don't need it
   export namespace Util {
     export const Exports = util_members;
@@ -168,5 +168,3 @@ namespace Drash {
     Loggers[name] = logger;
   }
 }
-
-export default Drash;

--- a/mod.ts
+++ b/mod.ts
@@ -4,39 +4,40 @@
 // REQUIREMENTS.md
 
 // Compilers
-import template_engine from "./src/compilers/template_engine.ts";
+import { TemplateEngine as template_engine } from "./src/compilers/template_engine.ts";
 
 // Dictionaries
 import * as log_levels from "./src/dictionaries/log_levels.ts";
 import mime_db from "./src/dictionaries/mime_db.json";
 
 // Exceptions
-import http_exception from "./src/exceptions/http_exception.ts";
-import http_middleware_exception from "./src/exceptions/http_middleware_exception.ts";
-import http_response_exception from "./src/exceptions/http_response_exception.ts";
-import name_collision_exception from "./src/exceptions/name_collision_exception.ts";
+import { HttpException as http_exception } from "./src/exceptions/http_exception.ts";
+import { HttpMiddlewareException as http_middleware_exception } from "./src/exceptions/http_middleware_exception.ts";
+import { HttpResponseException as http_response_exception } from "./src/exceptions/http_response_exception.ts";
+import { NameCollisionException as name_collision_exception } from "./src/exceptions/name_collision_exception.ts";
 
 // Http
-import middleware from "./src/http/middleware.ts";
-import resource from "./src/http/resource.ts";
-import response from "./src/http/response.ts";
-import server from "./src/http/server.ts";
+import { Middleware as middleware } from "./src/http/middleware.ts";
+import { Resource as resource } from "./src/http/resource.ts";
+import { Response as response } from "./src/http/response.ts";
+import { Server as server } from "./src/http/server.ts";
 
 // Interfaces
-import interface_logger_configs from "./src/interfaces/logger_configs.ts";
-import interface_log_level_structure from "./src/interfaces/log_level_structure.ts";
-import interface_parsed_request_body from "./src/interfaces/parsed_request_body.ts";
-import interface_server_configs from "./src/interfaces/server_configs.ts";
-import interface_response_options from "./src/interfaces/response_options.ts"
+import { LoggerConfigs as interface_logger_configs } from "./src/interfaces/logger_configs.ts";
+import { LogLevelStructure as interface_log_level_structure } from "./src/interfaces/log_level_structure.ts";
+import { ParsedRequestBody as interface_parsed_request_body } from "./src/interfaces/parsed_request_body.ts";
+import { ServerConfigs as interface_server_configs } from "./src/interfaces/server_configs.ts";
+import { ResponseOptions as interface_response_options } from "./src/interfaces/response_options.ts"
 
 // Loggers
-import base_logger from "./src/core_loggers/logger.ts";
-import console_logger from "./src/core_loggers/console_logger.ts";
-import file_logger from "./src/core_loggers/file_logger.ts";
+import { Logger as base_logger } from "./src/core_loggers/logger.ts";
+import { ConsoleLogger as console_logger } from "./src/core_loggers/console_logger.ts";
+import { FileLogger as file_logger } from "./src/core_loggers/file_logger.ts";
 
 // Services
-import http_service from "./src/services/http_service.ts";
-import http_request_service from "./src/services/http_request_service.ts";
+import { HttpService as http_service } from "./src/services/http_service.ts";
+import { HttpRequestService as http_request_service } from "./src/services/http_request_service.ts";
+import { StringService as string_service } from "./src/services/string_service.ts";
 
 import * as util_members from "./src/util/members.ts";
 
@@ -110,6 +111,8 @@ export namespace Drash {
     export const HttpService = new http_service();
     export type HttpRequestService = http_request_service;
     export const HttpRequestService = new http_request_service();
+    export type StringService = string_service;
+    export const StringService = string_service;
   }
 
   /**

--- a/mod.ts
+++ b/mod.ts
@@ -44,7 +44,7 @@ import * as util_members from "./src/util/members.ts";
 // FILE MARKER: NAMESPACE - DRASH //////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 //
-// Usage: import Drash from "/path/to/drash/mod.ts";
+// Usage: import { Drash } from "/path/to/drash/mod.ts";
 //
 
 export namespace Drash {

--- a/mod.ts
+++ b/mod.ts
@@ -47,7 +47,7 @@ import * as util_members from "./src/util/members.ts";
 // Usage: import Drash from "/path/to/drash/mod.ts";
 //
 
-export declare namespace Drash {
+export namespace Drash {
   // TODO: Remove this when the docs don't need it
   export namespace Util {
     export const Exports = util_members;
@@ -168,3 +168,5 @@ export declare namespace Drash {
     Loggers[name] = logger;
   }
 }
+
+export default Drash;

--- a/src/compilers/template_engine.ts
+++ b/src/compilers/template_engine.ts
@@ -2,11 +2,31 @@ const decoder = new TextDecoder();
 
 export default class TemplateEngine {
 
+  /**
+   * @description
+   *     A property to hold the base path to the template.
+   *
+   * @property string views_path
+   */
   public views_path: string = "";
+
+  // FILE MARKER: CONSTRUCTOR //////////////////////////////////////////////////
+
+  /**
+   * @description
+   *     Construct an object of this class.
+   *
+   * @param number code
+   *     The HTTP response code associated with this exception.
+   * @param string message
+   *     (optional) The exception message.
+   */
 
   constructor(viewsPath: string) {
     this.views_path = viewsPath;
   }
+
+  // FILE MARKER: METHODS - PUBLIC /////////////////////////////////////////////
 
   /**
    * Render a template file and replace all template variables with the

--- a/src/compilers/template_engine.ts
+++ b/src/compilers/template_engine.ts
@@ -4,7 +4,7 @@ export class TemplateEngine {
 
   /**
    * @description
-   *     A property to hold the base path to the template.
+   *     A property to hold the base path to the template(s).
    *
    * @property string views_path
    */
@@ -16,10 +16,8 @@ export class TemplateEngine {
    * @description
    *     Construct an object of this class.
    *
-   * @param number code
-   *     The HTTP response code associated with this exception.
-   * @param string message
-   *     (optional) The exception message.
+   * @param string viewsPath
+   *     The base path to the template(s).
    */
 
   constructor(viewsPath: string) {

--- a/src/compilers/template_engine.ts
+++ b/src/compilers/template_engine.ts
@@ -8,7 +8,16 @@ export default class TemplateEngine {
     this.views_path = viewsPath;
   }
 
-  public render(template: string, data: any) {
+  /**
+   * Render a template file and replace all template variables with the
+   * specified data.
+   *
+   * @param string template
+   *     The template to render.
+   * @param any data
+   *     The data that should be rendered with the template.
+   */
+  public render(template: string, data: any): string {
     let code: any = "with(obj) { var r=[];\n";
     let cursor: any = 0;
     let html: string = decoder.decode(Deno.readFileSync(this.views_path + template));

--- a/src/compilers/template_engine.ts
+++ b/src/compilers/template_engine.ts
@@ -1,6 +1,6 @@
 const decoder = new TextDecoder();
 
-export default class TemplateEngine {
+export class TemplateEngine {
 
   /**
    * @description

--- a/src/core_loggers/console_logger.ts
+++ b/src/core_loggers/console_logger.ts
@@ -1,6 +1,5 @@
 import { Drash } from "../../mod.ts";
-
-import Logger from "./logger.ts";
+import { Logger } from "./logger.ts";
 
 /**
  * @memberof Drash.CoreLoggers
@@ -9,7 +8,7 @@ import Logger from "./logger.ts";
  * @description
  *     This logger allows you to log messages to the console.
  */
-export default class ConsoleLogger extends Logger {
+export class ConsoleLogger extends Logger {
   /**
    * @description
    *     Construct an object of this class.

--- a/src/core_loggers/console_logger.ts
+++ b/src/core_loggers/console_logger.ts
@@ -1,4 +1,5 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
+
 import Logger from "./logger.ts";
 
 /**

--- a/src/core_loggers/file_logger.ts
+++ b/src/core_loggers/file_logger.ts
@@ -1,5 +1,5 @@
 import { Drash } from "../../mod.ts";
-import Logger from "./logger.ts";
+import { Logger } from "./logger.ts";
 
 /**
  * @memberof Drash.CoreLoggers
@@ -8,7 +8,7 @@ import Logger from "./logger.ts";
  * @description
  *     This logger allows you to log messages to a file.
  */
-export default class FileLogger extends Logger {
+export class FileLogger extends Logger {
   /**
    * @description
    *     The file this logger will write log messages to.

--- a/src/core_loggers/file_logger.ts
+++ b/src/core_loggers/file_logger.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 import Logger from "./logger.ts";
 
 /**

--- a/src/core_loggers/logger.ts
+++ b/src/core_loggers/logger.ts
@@ -1,5 +1,4 @@
 import { Drash } from "../../mod.ts";
-import LogLevels from "../dictionaries/log_levels.ts";
 
 /**
  * @memberof Drash.CoreLoggers
@@ -8,7 +7,7 @@ import LogLevels from "../dictionaries/log_levels.ts";
  * @description
  *     This Logger is the base logger class for all logger classes.
  */
-export default abstract class Logger {
+export abstract class Logger {
   /**
    * @description
    *     See Drash.Interfaces.LoggerConfigs
@@ -49,7 +48,7 @@ export default abstract class Logger {
     }
 
     configs.level = configs.level ? configs.level.toLowerCase() : "debug";
-    if (!LogLevels.get(configs.level)) {
+    if (!Drash.Dictionaries.LogLevels.get(configs.level)) {
       configs.level = "debug";
     }
 
@@ -88,7 +87,7 @@ export default abstract class Logger {
    *     The log message.
    */
   public debug(message: string): string | void {
-    return this.sendToWriteMethod(LogLevels.get("debug"), message);
+    return this.sendToWriteMethod(Drash.Dictionaries.LogLevels.get("debug"), message);
   }
 
   /**
@@ -99,7 +98,7 @@ export default abstract class Logger {
    *     The log message.
    */
   public error(message: string): string | void {
-    return this.sendToWriteMethod(LogLevels.get("error"), message);
+    return this.sendToWriteMethod(Drash.Dictionaries.LogLevels.get("error"), message);
   }
 
   /**
@@ -110,7 +109,7 @@ export default abstract class Logger {
    *     The log message.
    */
   public fatal(message: string): string | void {
-    return this.sendToWriteMethod(LogLevels.get("fatal"), message);
+    return this.sendToWriteMethod(Drash.Dictionaries.LogLevels.get("fatal"), message);
   }
 
   /**
@@ -121,7 +120,7 @@ export default abstract class Logger {
    *     The log message.
    */
   public info(message: string): string | void {
-    return this.sendToWriteMethod(LogLevels.get("info"), message);
+    return this.sendToWriteMethod(Drash.Dictionaries.LogLevels.get("info"), message);
   }
 
   /**
@@ -132,7 +131,7 @@ export default abstract class Logger {
    *     The log message.
    */
   public trace(message: string): string | void {
-    return this.sendToWriteMethod(LogLevels.get("trace"), message);
+    return this.sendToWriteMethod(Drash.Dictionaries.LogLevels.get("trace"), message);
   }
 
   /**
@@ -143,7 +142,7 @@ export default abstract class Logger {
    *     The log message.
    */
   public warn(message: string): string | void {
-    return this.sendToWriteMethod(LogLevels.get("warn"), message);
+    return this.sendToWriteMethod(Drash.Dictionaries.LogLevels.get("warn"), message);
   }
 
   // FILE MARKER: METHODS - PROTECTED //////////////////////////////////////////
@@ -212,7 +211,7 @@ export default abstract class Logger {
     // wants to output FATAL log messages (has a rank of 400), then any log
     // message with a rank greater than that (ERROR, WARN, INFO, DEBUG, TRACE)
     // will NOT be processed.
-    const level = LogLevels.get(key);
+    const level = Drash.Dictionaries.LogLevels.get(key);
     if (!level) {
       return;
     }

--- a/src/core_loggers/logger.ts
+++ b/src/core_loggers/logger.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 import LogLevels from "../dictionaries/log_levels.ts";
 
 /**

--- a/src/dictionaries/log_levels.ts
+++ b/src/dictionaries/log_levels.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 
 /**
  * @memberof Drash.Dictionaries

--- a/src/dictionaries/log_levels.ts
+++ b/src/dictionaries/log_levels.ts
@@ -36,5 +36,3 @@ export const LogLevels = new Map<string, Drash.Interfaces.LogLevelStructure>([
   ["trace", { name: "Trace", rank: LogLevel.Trace }],
   ["all", { name: "All", rank: LogLevel.All }],
 ]);
-
-export default LogLevels;

--- a/src/exceptions/http_exception.ts
+++ b/src/exceptions/http_exception.ts
@@ -5,7 +5,7 @@
  * @description
  *     This class gives you a way to throw HTTP errors semantically.
  */
-export default class HttpException extends Error {
+export class HttpException extends Error {
   /**
    * @description
    *     A property to hold the HTTP response code associated with this

--- a/src/exceptions/http_middleware_exception.ts
+++ b/src/exceptions/http_middleware_exception.ts
@@ -8,7 +8,7 @@
  *     comes when you want to check which exception was thrown via
  *     exception.constructor.name.
  */
-export default class HttpMiddlewareException extends Error {
+export class HttpMiddlewareException extends Error {
   /**
    * @description
    *     A property to hold the HTTP response code associated with this

--- a/src/exceptions/http_response_exception.ts
+++ b/src/exceptions/http_response_exception.ts
@@ -8,7 +8,7 @@
  *     comes when you want to check which exception was thrown via
  *     exception.constructor.name.
  */
-export default class HttpResponseException extends Error {
+export class HttpResponseException extends Error {
   /**
    * @description
    *     A property to hold the HTTP response code associated with this

--- a/src/exceptions/name_collision_exception.ts
+++ b/src/exceptions/name_collision_exception.ts
@@ -7,7 +7,7 @@
  *     if you try to add two loggers via Drash.addLogger() with the same name,
  *     then this exception will be thrown because the names are colliding.
  */
-export default class NameCollisionException extends Error {
+export class NameCollisionException extends Error {
   /**
      * @description
      *     A property to hold the error message associated with this

--- a/src/http/middleware.ts
+++ b/src/http/middleware.ts
@@ -7,7 +7,7 @@ import { Drash } from "../../mod.ts";
  * @description
  *     This is the base middleware class for all middleware classes.
  */
-export default abstract class Middleware {
+export abstract class Middleware {
   /**
    * @description
    *     A property to hold the name of this middleware class. This property is

--- a/src/http/middleware.ts
+++ b/src/http/middleware.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 
 /**
  * @memberof Drash.Http

--- a/src/http/resource.ts
+++ b/src/http/resource.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 
 /**
  * @memberof Drash.Http

--- a/src/http/resource.ts
+++ b/src/http/resource.ts
@@ -8,7 +8,7 @@ import { Drash } from "../../mod.ts";
  *     This is the base resource class for all resources. All resource classes
  *     must be derived from this class.
  */
-export default class Resource {
+export class Resource {
   /**
    * @description
    *     A property to hold the middleware this resource uses.

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 import { STATUS_TEXT, Status } from "../../deps.ts";
 import { setCookie, delCookie, Cookie } from "../../deps.ts";
 const decoder = new TextDecoder();

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -10,7 +10,7 @@ const decoder = new TextDecoder();
  * @description
  *     Response handles sending a response to the client making the request.
  */
-export default class Response {
+export class Response {
   /**
    * @description
    *     A property to hold the body of this response.

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,6 +1,5 @@
 import { Drash } from "../../mod.ts";
 import { STATUS_TEXT, Status, serve } from "../../deps.ts";
-import Resource from "./resource.ts";
 
 interface RunOptions {
   address?: string | any; // Use any to be more dynamic instead of using Pick
@@ -16,7 +15,7 @@ interface RunOptions {
  *     appropriate responses, and handling any errors that bubble up within the
  *     request-resource-response lifecycle.
  */
-export default class Server {
+export class Server {
   static REGEX_URI_MATCHES = new RegExp(/(:[^(/]+|{[^0-9][^}]*})/, "g");
   static REGEX_URI_REPLACEMENT = "([^/]+)";
   protected trackers = {
@@ -433,8 +432,8 @@ export default class Server {
    *     Returns an instance of the resourceClass passed in, and setting the
    *     `paths` and `middleware` properties
    */
-  public getResourceObject(resourceClass: any, request: any): Resource {
-    let resourceObj: Resource = new resourceClass(
+  public getResourceObject(resourceClass: any, request: any): Drash.Http.Resource {
+    let resourceObj: Drash.Http.Resource = new resourceClass(
       request,
       new Drash.Http.Response(request, {
         views_path: this.configs.views_path,

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 import { STATUS_TEXT, Status, serve } from "../../deps.ts";
 import Resource from "./resource.ts";
 

--- a/src/interfaces/log_level_structure.ts
+++ b/src/interfaces/log_level_structure.ts
@@ -13,7 +13,7 @@
  *         Drash.Dictionaries.LogLevels.LogLevel enum member to see the ranking
  *         structure of the log levels.
  */
-export default interface LogLevelStructure {
+export interface LogLevelStructure {
   name: string;
   rank: number;
 }

--- a/src/interfaces/logger_configs.ts
+++ b/src/interfaces/logger_configs.ts
@@ -50,7 +50,7 @@
  *         silence the console logger from outputting to the console so you can
  *         test without actually logging to the console.
  */
-export default interface LoggerConfigs {
+export interface LoggerConfigs {
   enabled: boolean;
   file?: string;
   level?: string;

--- a/src/interfaces/parsed_request_body.ts
+++ b/src/interfaces/parsed_request_body.ts
@@ -12,7 +12,7 @@
  *
  *         The data passed in the body of the request.
  */
-export default interface ParsedRequestBody {
+export interface ParsedRequestBody {
   content_type: any | undefined;
   data: any | undefined;
 }

--- a/src/interfaces/response_options.ts
+++ b/src/interfaces/response_options.ts
@@ -24,7 +24,7 @@
  *               template_engine: true
  *             })
  */
-export default interface ResponseOptions {
+export interface ResponseOptions {
     views_path?: string;
     template_engine?: boolean
 }

--- a/src/interfaces/server_configs.ts
+++ b/src/interfaces/server_configs.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 
 /**
  * @memberof Drash.Interfaces

--- a/src/interfaces/server_configs.ts
+++ b/src/interfaces/server_configs.ts
@@ -110,7 +110,7 @@ import { Drash } from "../../mod.ts";
  *               template_engine: true
  *             })
  */
-export default interface ServerConfigs {
+export interface ServerConfigs {
   address?: string;
   directory?: string;
   logger?: Drash.CoreLoggers.ConsoleLogger | Drash.CoreLoggers.FileLogger;

--- a/src/services/http_request_service.ts
+++ b/src/services/http_request_service.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 import {
   FormFile,
   MultipartReader,

--- a/src/services/http_request_service.ts
+++ b/src/services/http_request_service.ts
@@ -4,7 +4,6 @@ import {
   MultipartReader,
   ServerRequest
 } from "../../deps.ts";
-import StringService from "./string_service.ts";
 import { getCookies, Cookie } from "../../deps.ts";
 type Reader = Deno.Reader;
 const decoder = new TextDecoder();
@@ -23,7 +22,7 @@ interface OptionsConfig {
  * @description
  *     This class helps perform HTTP request related processes.
  */
-export default class HttpRequestService {
+export class HttpRequestService {
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - PUBLIC //////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
@@ -218,7 +217,7 @@ export default class HttpRequestService {
       if (!queryParamsString) {
         queryParamsString = "";
       }
-      queryParams = StringService.parseQueryParamsString(queryParamsString);
+      queryParams = Drash.Services.StringService.parseQueryParamsString(queryParamsString);
     } catch (error) {}
 
     return queryParams;
@@ -454,7 +453,7 @@ export default class HttpRequestService {
       body = body.split("?")[1];
     }
     body = body.replace(/\"/g, "");
-    return StringService.parseQueryParamsString(body);
+    return Drash.Services.StringService.parseQueryParamsString(body);
   }
 
   /**

--- a/src/services/http_service.ts
+++ b/src/services/http_service.ts
@@ -10,7 +10,7 @@ import {
  * @description
  *     This class helps perform HTTP-related processes.
  */
-export default class HttpService {
+export class HttpService {
   /**
    * @description
    *     Get a MIME type for a file based on its extension.

--- a/src/services/http_service.ts
+++ b/src/services/http_service.ts
@@ -1,4 +1,4 @@
-import Drash from "../../mod.ts";
+import { Drash } from "../../mod.ts";
 import {
   MultipartReader
 } from "../../deps.ts";

--- a/src/services/string_service.ts
+++ b/src/services/string_service.ts
@@ -6,7 +6,7 @@
  *     This class helps perform string-related processes like string
  *     transformations, reading, and replacing.
  */
-export default class StringService {
+export class StringService {
   /**
    * @description
    *     Parse a URL query string in it's raw form.

--- a/tests/members.ts
+++ b/tests/members.ts
@@ -1,4 +1,4 @@
-import Drash from "../mod.ts";
+import { Drash } from "../mod.ts";
 import {
   ServerRequest,
   assertEquals,

--- a/tests/unit/dictionaries/log_levels_test.ts
+++ b/tests/unit/dictionaries/log_levels_test.ts
@@ -1,9 +1,5 @@
 import members from "../../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       log_levels.ts");
-});
-
 let expected = {
   all: {
     rank: 7,
@@ -45,6 +41,6 @@ for (let logLevel in expected) {
   actual[logLevel] = members.Drash.Dictionaries.LogLevels.get(logLevel);
 }
 
-members.test("LogLevels", () => {
+members.test("log_levels_test.ts | LogLevels", () => {
   members.assert.equal(actual, expected);
 });

--- a/tests/unit/exceptions/http_exception_test.ts
+++ b/tests/unit/exceptions/http_exception_test.ts
@@ -1,15 +1,11 @@
 import members from "../../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       http_exception.ts");
-});
-
-members.test("Exceptions.HttpException(405)", () => {
+members.test("http_exception_test.ts | Exceptions.HttpException(405)", () => {
   let actual = new members.Drash.Exceptions.HttpException(405);
   members.assert.equal(actual.code, 405);
 });
 
-members.test("Exceptions.HttpException(418)", () => {
+members.test("http_exception_test.ts | Exceptions.HttpException(418)", () => {
   let actual = new members.Drash.Exceptions.HttpException(418);
   members.assert.equal(actual.code, 418);
 });

--- a/tests/unit/exceptions/name_collision_test.ts
+++ b/tests/unit/exceptions/name_collision_test.ts
@@ -1,10 +1,6 @@
 import members from "../../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       name_collisions_test.ts");
-});
-
-members.test("Exceptions.NameCollisionException('Error')", () => {
+members.test("name_collision_test.ts | Exceptions.NameCollisionException('Error')", () => {
   let actual = new members.Drash.Exceptions.NameCollisionException("Error");
   members.assert.equal(actual.message, "Error");
 });

--- a/tests/unit/http/middleware_test.ts
+++ b/tests/unit/http/middleware_test.ts
@@ -1,13 +1,9 @@
 import members from "../../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       middleware.ts");
-});
-
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server/resource: missing CSRF token", async () => {
+members.test("middleware_test.ts | server/resource: missing CSRF token", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -34,7 +30,7 @@ members.test("server/resource: missing CSRF token", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server/resource: wrong CSRF token", async () => {
+members.test("middleware_test.ts | server/resource: wrong CSRF token", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -65,7 +61,7 @@ members.test("server/resource: wrong CSRF token", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server/resource: user is not an admin", async () => {
+members.test("middleware_test.ts | server/resource: user is not an admin", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -97,7 +93,7 @@ members.test("server/resource: user is not an admin", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server/resource: pass", async () => {
+members.test("middleware_test.ts | server/resource: pass", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -126,7 +122,7 @@ members.test("server/resource: pass", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server/resource: middleware not found", async () => {
+members.test("middleware_test.ts | server/resource: middleware not found", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -147,7 +143,7 @@ members.test("server/resource: middleware not found", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server before_response: missing header", async () => {
+members.test("middleware_test.ts | server before_response: missing header", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -173,7 +169,7 @@ members.test("server before_response: missing header", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server before_response: wrong header", async () => {
+members.test("middleware_test.ts | server before_response: wrong header", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -203,7 +199,7 @@ members.test("server before_response: wrong header", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server before_response: pass", async () => {
+members.test("middleware_test.ts | server before_response: pass", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -230,7 +226,7 @@ members.test("server before_response: pass", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server before_request: missing header", async () => {
+members.test("middleware_test.ts | server before_request: missing header", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -256,7 +252,7 @@ members.test("server before_request: missing header", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server before_request: wrong header", async () => {
+members.test("middleware_test.ts | server before_request: wrong header", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {
@@ -286,7 +282,7 @@ members.test("server before_request: wrong header", async () => {
 /**
  * @covers Server.handleHttpRequest()
  */
-members.test("server before_request: pass", async () => {
+members.test("middleware_test.ts | server before_request: pass", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     middleware: {

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -1,10 +1,6 @@
 import members from "../../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       server.ts");
-});
-
-members.test("handleHttpRequest(): GET", async () => {
+members.test("server_test.ts | handleHttpRequest(): GET", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     resources: [HomeResource],
@@ -19,7 +15,7 @@ members.test("handleHttpRequest(): GET", async () => {
   server.close();
 });
 
-members.test("handleHttpRequest(): POST", async () => {
+members.test("server_test.ts | handleHttpRequest(): POST", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     resources: [HomeResource],
@@ -67,7 +63,7 @@ members.test(
   },
 );
 
-members.test("handleHttpRequest(): getHeaderParam()", async () => {
+members.test("server_test.ts | handleHttpRequest(): getHeaderParam()", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     resources: [GetHeaderParam],
@@ -88,7 +84,7 @@ members.test("handleHttpRequest(): getHeaderParam()", async () => {
   server.close();
 });
 
-members.test("handleHttpRequest(): getUrlQueryParam()", async () => {
+members.test("server_test.ts | handleHttpRequest(): getUrlQueryParam()", async () => {
   let server = new members.MockServer({
     address: "localhost:1557",
     resources: [GetUrlQueryParam],

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -38,7 +38,7 @@ members.test("server_test.ts | handleHttpRequest(): POST", async () => {
 });
 
 members.test(
-  "handleHttpRequest(): getPathParam() for :id and {id}",
+  "server_test.ts | handleHttpRequest(): getPathParam() for :id and {id}",
   async () => {
     let server = new members.MockServer({
       address: "localhost:1557",
@@ -102,7 +102,7 @@ members.test("server_test.ts | handleHttpRequest(): getUrlQueryParam()", async (
 });
 
 members.test(
-  "handleHttpRequest(): response.redirect()",
+  "server_test.ts | handleHttpRequest(): response.redirect()",
   async () => {
     let server = new members.MockServer({
       address: "localhost:1557",

--- a/tests/unit/loggers/console_logger_test.ts
+++ b/tests/unit/loggers/console_logger_test.ts
@@ -1,14 +1,10 @@
 import members from "../../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       console_logger.ts");
-});
-
 const ANIMALS = {
   "#1235": "tiger",
 };
 
-members.test("ConsoleLogger", () => {
+members.test("console_logger_test.ts | ConsoleLogger", () => {
   let expected = "some_date | hello | tiger | This is cool!";
   let logger = new members.Drash.CoreLoggers.ConsoleLogger({
     test: true,

--- a/tests/unit/loggers/file_logger_test.ts
+++ b/tests/unit/loggers/file_logger_test.ts
@@ -1,9 +1,5 @@
 import members from "../../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       file_logger.ts");
-});
-
 const ANIMALS = {
   "#1235": "tiger",
 };

--- a/tests/unit/mod_test.ts
+++ b/tests/unit/mod_test.ts
@@ -1,10 +1,6 @@
 import members from "../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       mod.ts");
-});
-
-members.test("Drash.addMember(): class", () => {
+members.test("mod_test.ts | Drash.addMember(): class", () => {
   class SomeCoolService {
     public coolify() {
       return "OK!";
@@ -16,7 +12,7 @@ members.test("Drash.addMember(): class", () => {
   members.assert.equal(service.coolify(), expected);
 });
 
-members.test("Drash.addMember(): function", () => {
+members.test("mod_test.ts | Drash.addMember(): function", () => {
   let SomeCoolServiceFunction = function (arg: string): string {
     return `You specified the following arg: ${arg}`;
   };
@@ -29,7 +25,7 @@ members.test("Drash.addMember(): function", () => {
   members.assert.equal(actual, expected);
 });
 
-members.test("Drash.addMember(): object", () => {
+members.test("mod_test.ts | Drash.addMember(): object", () => {
   let SomeCoolDictionary = {
     "Item 1": {
       definition: "This is Item 1. It is cool.",
@@ -51,7 +47,7 @@ members.test("Drash.addMember(): object", () => {
   members.assert.equal(actual, expected);
 });
 
-members.test("Drash.addMember(): types", () => {
+members.test("mod_test.ts | Drash.addMember(): types", () => {
   let data: any = {
     myBooleanTrue: true,
     myBooleanFalse: false,
@@ -70,7 +66,7 @@ members.test("Drash.addMember(): types", () => {
   }
 });
 
-members.test("Drash.addLogger(): class", () => {
+members.test("mod_test.ts | Drash.addLogger(): class", () => {
   const testLogger = new members.Drash.CoreLoggers.FileLogger({
     enabled: true,
     level: "debug",
@@ -82,7 +78,7 @@ members.test("Drash.addLogger(): class", () => {
   members.assert.equal(members.Drash.Loggers, expected);
 });
 
-members.test("Drash.addLogger(): names must be unique", () => {
+members.test("mod_test.ts | Drash.addLogger(): names must be unique", () => {
   const testLogger = new members.Drash.CoreLoggers.FileLogger({
     enabled: true,
     level: "debug",

--- a/tests/unit/services/http_request_service_test.ts
+++ b/tests/unit/services/http_request_service_test.ts
@@ -1,5 +1,1 @@
 import members from "../../members.ts";
-
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       http_request_service.ts");
-});

--- a/tests/unit/services/http_service_test.ts
+++ b/tests/unit/services/http_service_test.ts
@@ -1,10 +1,6 @@
 import members from "../../members.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       http_service.ts");
-});
-
-members.test("getMimeType(): file is not a URL", () => {
+members.test("http_service_test.ts | getMimeType(): file is not a URL", () => {
   let actual;
 
   actual = members.Drash.Services.HttpService.getMimeType(
@@ -28,7 +24,7 @@ members.test("getMimeType(): file is not a URL", () => {
   members.assert.equal(actual, "application/pdf");
 });
 
-members.test("getMimeType(): file is a URL", () => {
+members.test("http_service_test.ts | getMimeType(): file is a URL", () => {
   let actual;
 
   actual = members.Drash.Services.HttpService.getMimeType(

--- a/tests/unit_minimal/server_test.ts
+++ b/tests/unit_minimal/server_test.ts
@@ -1,11 +1,7 @@
 import members from "../members.ts";
 import Server from "../../src/http/server.ts";
 
-members.test("--------------------------------------------------------", () => {
-  console.log("\n       (minimal) server.ts");
-});
-
-members.test("handleHttpRequest(): GET", async () => {
+members.test("minimal server_test.ts | handleHttpRequest(): GET", async () => {
   let server = new Server({
     address: "localhost:1557",
     resources: [HomeResource],
@@ -20,7 +16,7 @@ members.test("handleHttpRequest(): GET", async () => {
   server.close();
 });
 
-members.test("handleHttpRequest(): POST", async () => {
+members.test("minimal server_test.ts | handleHttpRequest(): POST", async () => {
   let server = new Server({
     address: "localhost:1557",
     resources: [HomeResource],
@@ -68,7 +64,7 @@ members.test(
   },
 );
 
-members.test("handleHttpRequest(): getHeaderParam()", async () => {
+members.test("minimal server_test.ts | handleHttpRequest(): getHeaderParam()", async () => {
   let server = new Server({
     address: "localhost:1557",
     resources: [GetHeaderParam],
@@ -89,7 +85,7 @@ members.test("handleHttpRequest(): getHeaderParam()", async () => {
   server.close();
 });
 
-members.test("handleHttpRequest(): getUrlQueryParam()", async () => {
+members.test("minimal server_test.ts | handleHttpRequest(): getUrlQueryParam()", async () => {
   let server = new Server({
     address: "localhost:1557",
     resources: [GetUrlQueryParam],

--- a/tests/unit_minimal/server_test.ts
+++ b/tests/unit_minimal/server_test.ts
@@ -39,7 +39,7 @@ members.test("minimal server_test.ts | handleHttpRequest(): POST", async () => {
 });
 
 members.test(
-  "handleHttpRequest(): getPathParam() for :id and {id}",
+  "minimal server_test.ts | handleHttpRequest(): getPathParam() for :id and {id}",
   async () => {
     let server = new Server({
       address: "localhost:1557",

--- a/tests/unit_minimal/server_test.ts
+++ b/tests/unit_minimal/server_test.ts
@@ -1,5 +1,5 @@
 import members from "../members.ts";
-import Server from "../../src/http/server.ts";
+import { Server } from "../../src/http/server.ts";
 
 members.test("minimal server_test.ts | handleHttpRequest(): GET", async () => {
   let server = new Server({


### PR DESCRIPTION
Addresses #175 

This is a breaking change PR. Drash will now need to be imported like ...

```
import { Drash } from "https://deno.land/x/drash/mod.ts";
```

instead of ...

```
import Drash from "https://deno.land/x/drash/mod.ts";
```