### PR TITLE
Added version property to Drash namespace

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -34,7 +34,7 @@ git checkout upgrade-deno
 git pull
 ```
 
-Update the `deps.ts` file automaticlaly by updating line the `bumpVersions()` call in `console/typescript/bump_versions.ts`. This call should reflect which version to update from and which version to update to. See below as an example.
+Update the `deps.ts` file automatically by updating line the `bumpVersions()` call in `console/typescript/bump_versions.ts`. This call should reflect which version to update from and which version to update to. See below as an example.
 
 ```typescript
 let result = await bumpVersions(fromVersion, toVersion);
@@ -44,6 +44,11 @@ Run the following command.
 
 ```
 console/bump_verisons
+```
+
+Update the version property in `mod.ts`:
+```typescript
+export const version: string = "the new version here"; // "v0.41.1"
 ```
 
 Update `README.md`.

--- a/console/typescript/bump_versions.ts
+++ b/console/typescript/bump_versions.ts
@@ -5,12 +5,6 @@ async function bumpVersions(fromV: string, toV: string) {
   );
   depData = depData.replace(new RegExp(fromV, "g"), toV);
   Deno.writeFileSync("./deps.ts", new TextEncoder().encode(depData));
-  // Drash.version
-  let modData = new TextDecoder().decode(
-      await Deno.readAll(await Deno.open("./mod.ts"))
-  );
-  modData = modData.replace(new RegExp(fromV), toV);
-  Deno.writeFileSync("./mod.ts", new TextEncoder().encode(modData));
 
   return depData;
 }

--- a/console/typescript/bump_versions.ts
+++ b/console/typescript/bump_versions.ts
@@ -1,10 +1,18 @@
 async function bumpVersions(fromV: string, toV: string) {
-  let data = new TextDecoder().decode(
+  // deps.ts
+  let depData = new TextDecoder().decode(
     await Deno.readAll(await Deno.open("./deps.ts")),
   );
-  data = data.replace(new RegExp(fromV, "g"), toV);
-  Deno.writeFileSync("./deps.ts", new TextEncoder().encode(data));
-  return data;
+  depData = depData.replace(new RegExp(fromV, "g"), toV);
+  Deno.writeFileSync("./deps.ts", new TextEncoder().encode(depData));
+  // Drash.version
+  let modData = new TextDecoder().decode(
+      await Deno.readAll(await Deno.open("./mod.ts"))
+  );
+  modData = modData.replace(new RegExp(fromV), toV);
+  Deno.writeFileSync("./mod.ts", new TextEncoder().encode(modData));
+
+  return depData;
 }
 
 let result = await bumpVersions("v0.39.6", "v0.41.0");

--- a/mod.ts
+++ b/mod.ts
@@ -63,7 +63,7 @@ export namespace Drash {
    *
    * @property string version
    */
-  export const version: string = "v0.41.0";
+  export const version: string = "v0.41.1";
 
   export namespace Decorators {
     export type MiddlewareFunction = MiddlewareFunctionDefinition;

--- a/mod.ts
+++ b/mod.ts
@@ -56,6 +56,15 @@ export namespace Drash {
     export const Exports = util_members;
   }
 
+  /**
+   * @description
+   *     Drash version. Also represents what Deno version is
+   *     supported.
+   *
+   * @property string version
+   */
+  export const version: string = "v0.41.0";
+
   export namespace Decorators {
     export type MiddlewareFunction = MiddlewareFunctionDefinition;
     export type MiddlewareType = MiddlewareTypeDefinition;

--- a/tests/unit/mod_test.ts
+++ b/tests/unit/mod_test.ts
@@ -92,3 +92,8 @@ members.test("mod_test.ts | Drash.addLogger(): names must be unique", () => {
     'Loggers must be unique: "TestLogger" was already added.',
   );
 });
+
+members.test("mod_test.ts | Drash.version: must be current version", () => {
+  const version = members.Drash.version
+  members.assert.equals(version, "v0.41.0")
+})

--- a/tests/unit/mod_test.ts
+++ b/tests/unit/mod_test.ts
@@ -95,5 +95,5 @@ members.test("mod_test.ts | Drash.addLogger(): names must be unique", () => {
 
 members.test("mod_test.ts | Drash.version: must be current version", () => {
   const version = members.Drash.version
-  members.assert.equals(version, "v0.41.0")
+  members.assert.equals(version, "v0.41.1")
 })


### PR DESCRIPTION
Added a `version` property to the `Drash` namespace.

Also updated the `console/typescript/bump_versions` script to include the updating of the string in `mod.ts`

Example usage:

```typescript
import { Drash } from "https://deno.land/x/drash@v0.41.0/mod.ts";
console.log(Drash.version) // "v0.41.0"
```