### PR TITLE
Improved middleware API

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -11,8 +11,6 @@ import {
   Middleware as MiddlewareHandler,
   MiddlewareFunction as MiddlewareFunctionDefinition,
   MiddlewareType as MiddlewareTypeDefinition,
-  MethodMiddleware as MethodMiddlewareHandler,
-  ClassMiddleware as ClassMiddlewareHandler,
 } from "./src/http/middleware.ts";
 
 // Dictionaries
@@ -65,11 +63,8 @@ export namespace Drash {
    */
   export const version: string = "v0.41.1";
 
-  export namespace Decorators {
-  }
-
   export namespace Compilers {
-    export class TemplateEngine extends BaseTemplateEngine {}
+    export class TemplateEngine extends BaseTemplateEngine { }
   }
 
   export namespace Dictionaries {
@@ -78,41 +73,39 @@ export namespace Drash {
   }
 
   export namespace Exceptions {
-    export class HttpException extends BaseHttpException {}
-    export class HttpMiddlewareException extends BaseHttpMiddlewareException {}
-    export class HttpResponseException extends BaseHttpResponseException {}
-    export class NameCollisionException extends BaseNameCollisionException {}
+    export class HttpException extends BaseHttpException { }
+    export class HttpMiddlewareException extends BaseHttpMiddlewareException { }
+    export class HttpResponseException extends BaseHttpResponseException { }
+    export class NameCollisionException extends BaseNameCollisionException { }
   }
 
   export namespace CoreLoggers {
-    export class ConsoleLogger extends BaseConsoleLogger {}
-    export class FileLogger extends BaseFileLogger {}
-    export abstract class Logger extends BaseLogger {}
+    export class ConsoleLogger extends BaseConsoleLogger { }
+    export class FileLogger extends BaseFileLogger { }
+    export abstract class Logger extends BaseLogger { }
   }
 
   export namespace Http {
     export type MiddlewareFunction = MiddlewareFunctionDefinition;
     export type MiddlewareType = MiddlewareTypeDefinition;
     export const Middleware = MiddlewareHandler;
-    export const MethodMiddleware = MethodMiddlewareHandler;
-    export const ClassMiddleware = ClassMiddlewareHandler;
-    export class Resource extends BaseResource {}
-    export class Response extends BaseResponse {}
-    export class Server extends BaseServer {}
+    export class Resource extends BaseResource { }
+    export class Response extends BaseResponse { }
+    export class Server extends BaseServer { }
   }
 
   export namespace Interfaces {
-    export interface LogLevelStructure extends BaseLogLevelStructure {}
-    export interface LoggerConfigs extends BaseLoggerConfigs {}
-    export interface ParsedRequestBody extends BaseParsedRequestBody {}
-    export interface ServerConfigs extends BaseServerConfigs {}
-    export interface ResponseOptions extends BaseResponseOptions {}
+    export interface LogLevelStructure extends BaseLogLevelStructure { }
+    export interface LoggerConfigs extends BaseLoggerConfigs { }
+    export interface ParsedRequestBody extends BaseParsedRequestBody { }
+    export interface ServerConfigs extends BaseServerConfigs { }
+    export interface ResponseOptions extends BaseResponseOptions { }
   }
 
   export namespace Services {
-    export class HttpService extends BaseHttpService {}
-    export class HttpRequestService extends BaseHttpRequestService {}
-    export class StringService extends BaseStringService {}
+    export class HttpService extends BaseHttpService { }
+    export class HttpRequestService extends BaseHttpRequestService { }
+    export class StringService extends BaseStringService { }
   }
 
   /**

--- a/mod.ts
+++ b/mod.ts
@@ -64,7 +64,7 @@ export namespace Drash {
   export const version: string = "v0.41.1";
 
   export namespace Compilers {
-    export class TemplateEngine extends BaseTemplateEngine { }
+    export class TemplateEngine extends BaseTemplateEngine {}
   }
 
   export namespace Dictionaries {
@@ -73,39 +73,39 @@ export namespace Drash {
   }
 
   export namespace Exceptions {
-    export class HttpException extends BaseHttpException { }
-    export class HttpMiddlewareException extends BaseHttpMiddlewareException { }
-    export class HttpResponseException extends BaseHttpResponseException { }
-    export class NameCollisionException extends BaseNameCollisionException { }
+    export class HttpException extends BaseHttpException {}
+    export class HttpMiddlewareException extends BaseHttpMiddlewareException {}
+    export class HttpResponseException extends BaseHttpResponseException {}
+    export class NameCollisionException extends BaseNameCollisionException {}
   }
 
   export namespace CoreLoggers {
-    export class ConsoleLogger extends BaseConsoleLogger { }
-    export class FileLogger extends BaseFileLogger { }
-    export abstract class Logger extends BaseLogger { }
+    export class ConsoleLogger extends BaseConsoleLogger {}
+    export class FileLogger extends BaseFileLogger {}
+    export abstract class Logger extends BaseLogger {}
   }
 
   export namespace Http {
     export type MiddlewareFunction = MiddlewareFunctionDefinition;
     export type MiddlewareType = MiddlewareTypeDefinition;
     export const Middleware = MiddlewareHandler;
-    export class Resource extends BaseResource { }
-    export class Response extends BaseResponse { }
-    export class Server extends BaseServer { }
+    export class Resource extends BaseResource {}
+    export class Response extends BaseResponse {}
+    export class Server extends BaseServer {}
   }
 
   export namespace Interfaces {
-    export interface LogLevelStructure extends BaseLogLevelStructure { }
-    export interface LoggerConfigs extends BaseLoggerConfigs { }
-    export interface ParsedRequestBody extends BaseParsedRequestBody { }
-    export interface ServerConfigs extends BaseServerConfigs { }
-    export interface ResponseOptions extends BaseResponseOptions { }
+    export interface LogLevelStructure extends BaseLogLevelStructure {}
+    export interface LoggerConfigs extends BaseLoggerConfigs {}
+    export interface ParsedRequestBody extends BaseParsedRequestBody {}
+    export interface ServerConfigs extends BaseServerConfigs {}
+    export interface ResponseOptions extends BaseResponseOptions {}
   }
 
   export namespace Services {
-    export class HttpService extends BaseHttpService { }
-    export class HttpRequestService extends BaseHttpRequestService { }
-    export class StringService extends BaseStringService { }
+    export class HttpService extends BaseHttpService {}
+    export class HttpRequestService extends BaseHttpRequestService {}
+    export class StringService extends BaseStringService {}
   }
 
   /**

--- a/src/http/middleware.ts
+++ b/src/http/middleware.ts
@@ -6,9 +6,7 @@ import { Drash } from "../../mod.ts";
  * @param server Contains the instance of the server.
  * @param response Contains the instance of the response.
  */
-export type MiddlewareFunction =
-  | ((request: any, response: Drash.Http.Response) => Promise<void>)
-  | ((request: any, response: Drash.Http.Response) => void);
+export type MiddlewareFunction = ((request: any, response: Drash.Http.Response) => Promise<void>) | ((request: any, response: Drash.Http.Response) => void);
 
 /**
  * @type MiddlewareType
@@ -23,34 +21,36 @@ export type MiddlewareFunction =
  *
  */
 export type MiddlewareType = {
-  before_request?: MiddlewareFunction[];
-  after_request?: MiddlewareFunction[];
+    before_request?: MiddlewareFunction[];
+    after_request?: MiddlewareFunction[];
 };
 
 /**
  * Executes the middleware
- * 
+ *
  * @param middlewares Contains middlewares to be executed
  */
 export function Middleware(middlewares: MiddlewareType) {
-  return function (this: any, ...args: any) {
-    switch (args.length) {
-      case 1:
-        // Class decorator
-        return ClassMiddleware(middlewares).apply(this, args);
-      case 2:
-        // Property decorator
-        break;
-      case 3:
-        if (typeof args[2] == "number") {
-          // Parameter decorator
-          break;
+    return function (...args: any[]) {
+        switch (args.length) {
+            case 1:
+                // Class decorator
+                // @ts-ignore
+                return ClassMiddleware(middlewares).apply(this, args);
+            case 2:
+                // Property decorator
+                break;
+            case 3:
+                if (typeof args[2] == "number") {
+                    // Parameter decorator
+                    break;
+                }
+                // @ts-ignore
+                return MethodMiddleware(middlewares).apply(this, args);
+            default:
+                throw new Error("Not a valid decorator");
         }
-        return MethodMiddleware(middlewares).apply(this, args);
-      default:
-        throw new Error("Not a valid decorator");
-    }
-  };
+    };
 }
 
 /**
@@ -59,35 +59,31 @@ export function Middleware(middlewares: MiddlewareType) {
  * @param middlewares Contains all middleware to be run
  */
 export function MethodMiddleware(middlewares: MiddlewareType) {
-  return function (
-    target: any,
-    propertyKey: string,
-    descriptor: PropertyDescriptor,
-  ) {
-    const originalFunction = descriptor.value;
-    descriptor.value = async function (...args: any[]) {
-      const { request, response } = Object.getOwnPropertyDescriptors(this);
-      // Execute before_request Middleware if exist
-      if (middlewares.before_request != null) {
-        for (const middleware of middlewares.before_request) {
-          await middleware(request.value, response.value);
-        }
-      }
+    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+        const originalFunction = descriptor.value;
+        descriptor.value = async function (...args: any[]) {
+            const { request, response } = Object.getOwnPropertyDescriptors(this);
+            // Execute before_request Middleware if exist
+            if (middlewares.before_request != null) {
+                for (const middleware of middlewares.before_request) {
+                    await middleware(request.value, response.value);
+                }
+            }
 
-      // Execute function
-      const result = originalFunction.apply(this, args);
+            // Execute function
+            const result = originalFunction.apply(this, args);
 
-      // Execute after_request Middleware if exist
-      if (middlewares.after_request != null) {
-        for (const middleware of middlewares.after_request) {
-          await middleware(request.value, result);
-        }
-      }
-      return result;
+            // Execute after_request Middleware if exist
+            if (middlewares.after_request != null) {
+                for (const middleware of middlewares.after_request) {
+                    await middleware(request.value, result);
+                }
+            }
+            return result;
+        };
+
+        return descriptor;
     };
-
-    return descriptor;
-  };
 }
 
 /**
@@ -96,25 +92,25 @@ export function MethodMiddleware(middlewares: MiddlewareType) {
  * @param middlewares Contains all middleware to be run
  */
 export function ClassMiddleware(middlewares: MiddlewareType) {
-  return function <T extends { new (...args: any[]): {} }>(constr: T) {
-    return class extends constr {
-      constructor(...args: any[]) {
-        const request = args[0];
-        const response = args[1];
-        // Execute before_request Middleware if exist
-        if (middlewares.before_request != null) {
-          for (const middleware of middlewares.before_request) {
-            middleware(request, response);
-          }
-        }
-        super(...args);
-        // Execute after_request Middleware if exist
-        if (middlewares.after_request != null) {
-          for (const middleware of middlewares.after_request) {
-            middleware(request, response);
-          }
-        }
-      }
+    return function <T extends { new (...args: any[]): {} }>(constr: T) {
+        return class extends constr {
+            constructor(...args: any[]) {
+                const request = args[0];
+                const response = args[1];
+                // Execute before_request Middleware if exist
+                if (middlewares.before_request != null) {
+                    for (const middleware of middlewares.before_request) {
+                        middleware(request, response);
+                    }
+                }
+                super(...args);
+                // Execute after_request Middleware if exist
+                if (middlewares.after_request != null) {
+                    for (const middleware of middlewares.after_request) {
+                        middleware(request, response);
+                    }
+                }
+            }
+        };
     };
-  };
 }

--- a/src/http/middleware.ts
+++ b/src/http/middleware.ts
@@ -6,7 +6,9 @@ import { Drash } from "../../mod.ts";
  * @param server Contains the instance of the server.
  * @param response Contains the instance of the response.
  */
-export type MiddlewareFunction = ((request: any, response: Drash.Http.Response) => Promise<void>) | ((request: any, response: Drash.Http.Response) => void);
+export type MiddlewareFunction =
+  | ((request: any, response: Drash.Http.Response) => Promise<void>)
+  | ((request: any, response: Drash.Http.Response) => void);
 
 /**
  * @type MiddlewareType
@@ -21,8 +23,8 @@ export type MiddlewareFunction = ((request: any, response: Drash.Http.Response) 
  *
  */
 export type MiddlewareType = {
-    before_request?: MiddlewareFunction[];
-    after_request?: MiddlewareFunction[];
+  before_request?: MiddlewareFunction[];
+  after_request?: MiddlewareFunction[];
 };
 
 /**
@@ -31,26 +33,26 @@ export type MiddlewareType = {
  * @param middlewares Contains middlewares to be executed
  */
 export function Middleware(middlewares: MiddlewareType) {
-    return function (...args: any[]) {
-        switch (args.length) {
-            case 1:
-                // Class decorator
-                // @ts-ignore
-                return ClassMiddleware(middlewares).apply(this, args);
-            case 2:
-                // Property decorator
-                break;
-            case 3:
-                if (typeof args[2] == "number") {
-                    // Parameter decorator
-                    break;
-                }
-                // @ts-ignore
-                return MethodMiddleware(middlewares).apply(this, args);
-            default:
-                throw new Error("Not a valid decorator");
+  return function (...args: any[]) {
+    switch (args.length) {
+      case 1:
+        // Class decorator
+        // @ts-ignore
+        return ClassMiddleware(middlewares).apply(this, args);
+      case 2:
+        // Property decorator
+        break;
+      case 3:
+        if (typeof args[2] == "number") {
+          // Parameter decorator
+          break;
         }
-    };
+        // @ts-ignore
+        return MethodMiddleware(middlewares).apply(this, args);
+      default:
+        throw new Error("Not a valid decorator");
+    }
+  };
 }
 
 /**
@@ -59,31 +61,35 @@ export function Middleware(middlewares: MiddlewareType) {
  * @param middlewares Contains all middleware to be run
  */
 export function MethodMiddleware(middlewares: MiddlewareType) {
-    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
-        const originalFunction = descriptor.value;
-        descriptor.value = async function (...args: any[]) {
-            const { request, response } = Object.getOwnPropertyDescriptors(this);
-            // Execute before_request Middleware if exist
-            if (middlewares.before_request != null) {
-                for (const middleware of middlewares.before_request) {
-                    await middleware(request.value, response.value);
-                }
-            }
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const originalFunction = descriptor.value;
+    descriptor.value = async function (...args: any[]) {
+      const { request, response } = Object.getOwnPropertyDescriptors(this);
+      // Execute before_request Middleware if exist
+      if (middlewares.before_request != null) {
+        for (const middleware of middlewares.before_request) {
+          await middleware(request.value, response.value);
+        }
+      }
 
-            // Execute function
-            const result = originalFunction.apply(this, args);
+      // Execute function
+      const result = originalFunction.apply(this, args);
 
-            // Execute after_request Middleware if exist
-            if (middlewares.after_request != null) {
-                for (const middleware of middlewares.after_request) {
-                    await middleware(request.value, result);
-                }
-            }
-            return result;
-        };
-
-        return descriptor;
+      // Execute after_request Middleware if exist
+      if (middlewares.after_request != null) {
+        for (const middleware of middlewares.after_request) {
+          await middleware(request.value, result);
+        }
+      }
+      return result;
     };
+
+    return descriptor;
+  };
 }
 
 /**
@@ -92,25 +98,25 @@ export function MethodMiddleware(middlewares: MiddlewareType) {
  * @param middlewares Contains all middleware to be run
  */
 export function ClassMiddleware(middlewares: MiddlewareType) {
-    return function <T extends { new (...args: any[]): {} }>(constr: T) {
-        return class extends constr {
-            constructor(...args: any[]) {
-                const request = args[0];
-                const response = args[1];
-                // Execute before_request Middleware if exist
-                if (middlewares.before_request != null) {
-                    for (const middleware of middlewares.before_request) {
-                        middleware(request, response);
-                    }
-                }
-                super(...args);
-                // Execute after_request Middleware if exist
-                if (middlewares.after_request != null) {
-                    for (const middleware of middlewares.after_request) {
-                        middleware(request, response);
-                    }
-                }
-            }
-        };
+  return function <T extends { new (...args: any[]): {} }>(constr: T) {
+    return class extends constr {
+      constructor(...args: any[]) {
+        const request = args[0];
+        const response = args[1];
+        // Execute before_request Middleware if exist
+        if (middlewares.before_request != null) {
+          for (const middleware of middlewares.before_request) {
+            middleware(request, response);
+          }
+        }
+        super(...args);
+        // Execute after_request Middleware if exist
+        if (middlewares.after_request != null) {
+          for (const middleware of middlewares.after_request) {
+            middleware(request, response);
+          }
+        }
+      }
     };
+  };
 }

--- a/src/http/middleware.ts
+++ b/src/http/middleware.ts
@@ -60,7 +60,7 @@ export function Middleware(middlewares: MiddlewareType) {
  *
  * @param middlewares Contains all middleware to be run
  */
-export function MethodMiddleware(middlewares: MiddlewareType) {
+function MethodMiddleware(middlewares: MiddlewareType) {
   return function (
     target: any,
     propertyKey: string,
@@ -97,7 +97,7 @@ export function MethodMiddleware(middlewares: MiddlewareType) {
  *
  * @param middlewares Contains all middleware to be run
  */
-export function ClassMiddleware(middlewares: MiddlewareType) {
+function ClassMiddleware(middlewares: MiddlewareType) {
   return function <T extends { new (...args: any[]): {} }>(constr: T) {
     return class extends constr {
       constructor(...args: any[]) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
     "compilerOptions": {
-        "noImplicitThis": false,
-        "strictBindCallApply": false,
         "experimentalDecorators": true
     }
 }


### PR DESCRIPTION
Removed the need for middleware decorators to have extra configs in `tsconfig.json`.
```typescript
// Before
@Drash.Http.ClassMiddleware({ before_request: [LogAfter] })
class HomeResource extends Drash.Http.Resource {
    static paths = ["/"];
    @Drash.Http.MethodMiddleware({ before_request: [LogAfter] })
    public GET() {
        return this.response;
    }
}
```
```typescript
// After
@Drash.Http.Middleware({ before_request: [LogAfter] })
class HomeResource extends Drash.Http.Resource {
    static paths = ["/"];
    @Drash.Http.Middleware({ before_request: [LogAfter] })
    public GET() {
        return this.response;
    }
}
```

Before we could use that standalone `Middleware()` signature, but it required some horrible `tsconfig.json` like [this](https://github.com/drashland/deno-drash/pull/186#issuecomment-617353887).

The `tsconfig.json` now is only required to be:
```json
{
    "compilerOptions": {
        "experimentalDecorators": true
    }
}
```

With this, we effectively only provide one API for the user (`Drash.Http.Middleware`), regardless of being Class or Method.