### PR TITLE
Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.0.0-rc1
 2. Run the Drash application using `deno`.
 
 ```
-deno --allow-net --allow-env https://deno.land/x/drash@v1.0.0-rc1/example_app/app.ts
+deno --allow-net --allow-env https://deno.land/x/drash@v1.0.0-rc1/example_app/app_1.ts
 ```
 
 2. Make the following request: `GET /`.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.0.0-rc1
 2. Run the Drash application using `deno`.
 
 ```
-deno --allow-net --allow-env https://deno.land/x/drash@v1.0.0-rc1/example_app/app_1.ts
+deno --allow-net --allow-read --allow-env https://deno.land/x/drash@v1.0.0-rc1/example_app/app_1.ts
 ```
 
 2. Make the following request: `GET /`.


### PR DESCRIPTION
Fixes error when running example app

**Description**

* Running example command gave a 404 error

> $ deno --allow-net --allow-env https://deno.land/x/drash@v1.0.0-rc1/example_app/app.ts
Download https://deno.land/x/drash@v1.0.0-rc1/example_app/app.ts
Import 'https://deno.land/x/drash@v1.0.0-rc1/example_app/app.ts' failed: 404 Not Found


<img width="976" alt="Screenshot 2020-05-12 00 31 53" src="https://user-images.githubusercontent.com/149034/81642070-22935c80-93e8-11ea-82bc-b92478da9f9e.png">

* After getting correct URL, I received 

> error: Uncaught PermissionDenied: read access to "/Users/HOSTDIRECTORY", run again with the --allow-read flag
    at unwrapResponse ($deno$/ops/dispatch_json.ts:43:11)
    at Object.sendSync ($deno$/ops/dispatch_json.ts:72:10)
    at Object.realPathSync ($deno$/ops/fs/real_path.ts:5:10)
    at https://deno.land/x/drash@v1.0.0-rc1/example_app/app_1.ts:20:19


<img width="971" alt="Screenshot 2020-05-12 00 34 10" src="https://user-images.githubusercontent.com/149034/81642142-52dafb00-93e8-11ea-9e3c-993f8b5ea15b.png">
