### PR TITLE
upgrade deno to v1.0.1

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -46,7 +46,7 @@ Run the following command.
 console/bump_verisons
 ```
 
-Update the version property in `mod.ts`:
+Update the version property in `mod.ts` to Deno's (as shown in their releases):
 ```typescript
 export const version: string = "the new version here"; // "v0.41.1"
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 - [Documentation](#documentation)
 - [Features](#features)
 - [Why use Drash?](#why-use-drash)
-- [Example Drash App](#example-drash-app)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -107,67 +106,6 @@ Thrown into the mix is Drash's own concepts such as:
 * Lowering barriers to usage
 
 Drash does not force you to use all of its code. You can pick and choose which data members you want/need and use them however you deem fit. For example, Drash comes with a console logger and a file logger. If you only want these, then you only import these into your non-Drash project. How you use it is really up to you.
-
-## Example Drash App
-
-The [`example_app`](https://github.com/drashland/deno-drash/tree/master/example_app) directory contains an example Drash application. You can run it using `deno` locally.
-
-1. Install deno.
-
-```
-curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.0.1
-```
-
-2. Run the Drash application using `deno`.
-
-```
-deno run --allow-net --allow-read --allow-env https://deno.land/x/drash@v1.0.1/example_app/app_1.ts
-```
-
-2. Make the following request: `GET /`.
-
-```
-curl --request GET localhost:1447
-
-"GET request received!"
-```
-
-3. Make the following request `GET /coffee/17`.
-
-```
-curl --request GET localhost:1447/coffee/17
-
-{"name":"Light"}
-```
-
-4. Make the following request `POST /`.
-
-```
-curl --request POST localhost:1447
-
-"POST request received!"
-```
-
-5. Make the following request `PATCH /` (with verbose flag). This method is not defined in the [`HomeResource`](https://github.com/drashland/deno-drash/blob/master/example_app/home_resource.ts) class, so you should receive a `405` response.
-
-```
-curl --request PATCH --verbose localhost:1447
-
-*   Trying ::1...
-* TCP_NODELAY set
-* Connected to localhost (::1) port 1447 (#0)
-> PATCH / HTTP/1.1
-> Host: localhost:1447
-> User-Agent: curl/7.64.1
-> Accept: */*
->
-< HTTP/1.1 405 Method Not Allowed
-< content-type: application/json
-< content-length: 20
-<
-* Connection #0 to host localhost left intact
-"Method Not Allowed"* Closing connection 0
-```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ```typescript
 // File: app.ts
 
-import { Drash } from "https://deno.land/x/drash@v1.0.0/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.0.1/mod.ts";
 
 class HomeResource extends Drash.Http.Resource {
   static paths = ["/"];
@@ -115,13 +115,13 @@ The [`example_app`](https://github.com/drashland/deno-drash/tree/master/example_
 1. Install deno.
 
 ```
-curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.0.0
+curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.0.1
 ```
 
 2. Run the Drash application using `deno`.
 
 ```
-deno run --allow-net --allow-read --allow-env https://deno.land/x/drash@v1.0.0/example_app/app_1.ts
+deno run --allow-net --allow-read --allow-env https://deno.land/x/drash@v1.0.1/example_app/app_1.ts
 ```
 
 2. Make the following request: `GET /`.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,5 +1,9 @@
 # Requirements
 
+* v1.0.1
+
+    * Deno v1.0.1
+
 * v1.0.0
 
     * Deno v1.0.0

--- a/console/install_deno
+++ b/console/install_deno
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 (
-  export DENO_LATEST_VERSION="v0.42.0"
+  export DENO_LATEST_VERSION="v1.0.1"
   curl -fsSL https://deno.land/x/install/install.sh | sh -s $DENO_LATEST_VERSION
 )

--- a/console/typescript/bump_versions.ts
+++ b/console/typescript/bump_versions.ts
@@ -18,6 +18,6 @@ async function bumpVersions(fromV: string, toV: string) {
   return depData;
 }
 
-let result = await bumpVersions("v1.0.0", "v0.50.0");
+let result = await bumpVersions("v0.50.0", "v0.52.0");
 
 console.log(result);

--- a/deps.ts
+++ b/deps.ts
@@ -5,35 +5,35 @@ export {
   ServerRequest,
   serve,
   serveTLS,
-} from "https://deno.land/std@v0.50.0/http/server.ts";
+} from "https://deno.land/std@v0.52.0/http/server.ts";
 
 export {
   STATUS_TEXT,
   Status,
-} from "https://deno.land/std@v0.50.0/http/http_status.ts";
+} from "https://deno.land/std@v0.52.0/http/http_status.ts";
 
 export {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@v0.50.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.52.0/testing/asserts.ts";
 
 export {
   BufReader,
   ReadLineResult,
-} from "https://deno.land/std@v0.50.0/io/bufio.ts";
+} from "https://deno.land/std@v0.52.0/io/bufio.ts";
 
 export {
   StringReader,
-} from "https://deno.land/std@v0.50.0/io/readers.ts";
+} from "https://deno.land/std@v0.52.0/io/readers.ts";
 
 export {
   FormFile,
   MultipartReader,
-} from "https://deno.land/std@v0.50.0/mime/multipart.ts";
+} from "https://deno.land/std@v0.52.0/mime/multipart.ts";
 
 export {
   Cookie,
   delCookie,
   getCookies,
   setCookie,
-} from "https://deno.land/std@v0.50.0/http/cookie.ts";
+} from "https://deno.land/std@v0.52.0/http/cookie.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -49,7 +49,7 @@ export namespace Drash {
    *
    * @property string version
    */
-  export const version: string = "v1.0.0";
+  export const version: string = "v1.0.1";
 
   export namespace Compilers {
     export class TemplateEngine extends BaseTemplateEngine {}

--- a/tests/unit/mod_test.ts
+++ b/tests/unit/mod_test.ts
@@ -95,5 +95,5 @@ members.test("mod_test.ts | Drash.addLogger(): names must be unique", () => {
 
 members.test("mod_test.ts | Drash.version: must be current version", () => {
   const version = members.Drash.version;
-  members.assert.equals(version, "v1.0.0");
+  members.assert.equals(version, "v1.0.1");
 });


### PR DESCRIPTION
Upgrades deno to v1.0.1 from v1.0.0 (std 0.50.0)

**Description**

* Updated all references to deno's and drash's version to reflect the new one

**Other Notes**

* Any other useful information goes here