### PR TITLE
Upgrade deno to v1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ```typescript
 // File: app.ts
 
-import { Drash } from "https://deno.land/x/drash@v1.0.3/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.0.4/mod.ts";
 
 class HomeResource extends Drash.Http.Resource {
   static paths = ["/"];
@@ -77,13 +77,13 @@ To get started with the Create Drash App tool, see the following commands:
 ```
 $ mkdir my-drash-project
 $ cd my-drash-project
-$ deno run --allow-run --allow-read --allow-write https://deno.land/x/drash@v1.0.3/create_app.ts [OPTIONS]
+$ deno run --allow-run --allow-read --allow-write https://deno.land/x/drash@v1.0.4/create_app.ts [OPTIONS]
 ```
 
 Display the options with `--help`:
 
 ```
-$ deno run --allow-run https://deno.land/x/drash@v1.0.0/create_app.ts --help
+$ deno run --allow-run https://deno.land/x/drash@v1.0.4/create_app.ts --help
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ```typescript
 // File: app.ts
 
-import { Drash } from "https://deno.land/x/drash@v1.0.4/mod.ts";
+import { Drash } from "https://deno.land/x/drash@v1.0.5/mod.ts";
 
 class HomeResource extends Drash.Http.Resource {
   static paths = ["/"];
@@ -77,13 +77,13 @@ To get started with the Create Drash App tool, see the following commands:
 ```
 $ mkdir my-drash-project
 $ cd my-drash-project
-$ deno run --allow-run --allow-read --allow-write https://deno.land/x/drash@v1.0.4/create_app.ts [OPTIONS]
+$ deno run --allow-run --allow-read --allow-write https://deno.land/x/drash@v1.0.5/create_app.ts [OPTIONS]
 ```
 
 Display the options with `--help`:
 
 ```
-$ deno run --allow-run --allow-read https://deno.land/x/drash@v1.0.4/create_app.ts --help
+$ deno run --allow-run --allow-read https://deno.land/x/drash@v1.0.5/create_app.ts --help
 ```
 
 ## Documentation

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,5 +1,10 @@
 # Requirements
 
+* v1.0.5
+
+    * Deno v1.0.5
+    * Deno Standard Modules v0.56.0
+
 * v1.0.4
 
     * Deno v1.0.4

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,5 +1,10 @@
 # Requirements
 
+* v1.0.4
+
+    * Deno v1.0.4
+    * Deno Standard Modules v0.55.0
+
 * v1.0.3
 
     * Deno v1.0.3

--- a/console/install_deno
+++ b/console/install_deno
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 (
-  export DENO_LATEST_VERSION="v1.0.4"
+  export DENO_LATEST_VERSION="v1.0.5"
   curl -fsSL https://deno.land/x/install/install.sh | sh -s $DENO_LATEST_VERSION
 )

--- a/console/install_deno
+++ b/console/install_deno
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 (
-  export DENO_LATEST_VERSION="v1.0.2"
+  export DENO_LATEST_VERSION="v1.0.3"
   curl -fsSL https://deno.land/x/install/install.sh | sh -s $DENO_LATEST_VERSION
 )

--- a/console/install_deno
+++ b/console/install_deno
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 (
-  export DENO_LATEST_VERSION="v1.0.3"
+  export DENO_LATEST_VERSION="v1.0.4"
   curl -fsSL https://deno.land/x/install/install.sh | sh -s $DENO_LATEST_VERSION
 )

--- a/console/tests
+++ b/console/tests
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 (
-  cd example_app
-  deno run --allow-net --allow-read app_1.ts &
-  server_pid=$!
-  deno test --allow-net app_1_test.ts
-  kill $server_pid
+  # cd example_app
+  # deno run --allow-net --allow-read app_1.ts &
+  # server_pid=$!
+  # deno test --allow-net app_1_test.ts
+  # kill $server_pid
 
-  deno run --allow-net --allow-read app_2.ts &
-  server_pid=$!
-  deno test --allow-net app_2_test.ts
-  kill $server_pid
+  # deno run --allow-net --allow-read app_2.ts &
+  # server_pid=$!
+  # deno test --allow-net app_2_test.ts
+  # kill $server_pid
 
-  cd -
+  # cd -
   deno test tests/test.ts --config tsconfig.json --allow-net
 
   deno test tests/create_app_test.ts --allow-read --allow-write --allow-run

--- a/console/typescript/bump_versions.ts
+++ b/console/typescript/bump_versions.ts
@@ -6,6 +6,7 @@
  * - mod_test.ts
  * - README.md
  * - REQUIREMENTS.md
+ * - console/install_deno
  */
 async function bumpVersions(fromV: string, toV: string) {
   // deps.ts
@@ -18,6 +19,6 @@ async function bumpVersions(fromV: string, toV: string) {
   return depData;
 }
 
-let result = await bumpVersions("v0.53.0", "v0.54.0");
+let result = await bumpVersions("v0.54.0", "v0.55.0");
 
 console.log(result);

--- a/console/typescript/bump_versions.ts
+++ b/console/typescript/bump_versions.ts
@@ -19,6 +19,6 @@ async function bumpVersions(fromV: string, toV: string) {
   return depData;
 }
 
-let result = await bumpVersions("v0.54.0", "v0.55.0");
+let result = await bumpVersions("v0.55.0", "v0.56.0");
 
 console.log(result);

--- a/deps.ts
+++ b/deps.ts
@@ -5,38 +5,38 @@ export {
   ServerRequest,
   serve,
   serveTLS,
-} from "https://deno.land/std@v0.54.0/http/server.ts";
+} from "https://deno.land/std@v0.55.0/http/server.ts";
 
 export {
   STATUS_TEXT,
   Status,
-} from "https://deno.land/std@v0.54.0/http/http_status.ts";
+} from "https://deno.land/std@v0.55.0/http/http_status.ts";
 
 export {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@v0.54.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.55.0/testing/asserts.ts";
 
 export {
   BufReader,
   ReadLineResult,
-} from "https://deno.land/std@v0.54.0/io/bufio.ts";
+} from "https://deno.land/std@v0.55.0/io/bufio.ts";
 
 export {
   StringReader,
-} from "https://deno.land/std@v0.54.0/io/readers.ts";
+} from "https://deno.land/std@v0.55.0/io/readers.ts";
 
 export {
   FormFile,
   MultipartReader,
-} from "https://deno.land/std@v0.54.0/mime/multipart.ts";
+} from "https://deno.land/std@v0.55.0/mime/multipart.ts";
 
 export {
   Cookie,
   delCookie,
   getCookies,
   setCookie,
-} from "https://deno.land/std@v0.54.0/http/cookie.ts";
+} from "https://deno.land/std@v0.55.0/http/cookie.ts";
 
 export {
   red,

--- a/deps.ts
+++ b/deps.ts
@@ -5,40 +5,40 @@ export {
   ServerRequest,
   serve,
   serveTLS,
-} from "https://deno.land/std@v0.55.0/http/server.ts";
+} from "https://deno.land/std@v0.56.0/http/server.ts";
 
 export {
   STATUS_TEXT,
   Status,
-} from "https://deno.land/std@v0.55.0/http/http_status.ts";
+} from "https://deno.land/std@v0.56.0/http/http_status.ts";
 
 export {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@v0.55.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.56.0/testing/asserts.ts";
 
 export {
   BufReader,
   ReadLineResult,
-} from "https://deno.land/std@v0.55.0/io/bufio.ts";
+} from "https://deno.land/std@v0.56.0/io/bufio.ts";
 
 export {
   StringReader,
-} from "https://deno.land/std@v0.55.0/io/readers.ts";
+} from "https://deno.land/std@v0.56.0/io/readers.ts";
 
 export {
   FormFile,
   MultipartReader,
-} from "https://deno.land/std@v0.55.0/mime/multipart.ts";
+} from "https://deno.land/std@v0.56.0/mime/multipart.ts";
 
 export {
   Cookie,
   delCookie,
   getCookies,
   setCookie,
-} from "https://deno.land/std@v0.55.0/http/cookie.ts";
+} from "https://deno.land/std@v0.56.0/http/cookie.ts";
 
 export {
   red,
   green,
-} from "https://deno.land/std@0.53.0/fmt/colors.ts";
+} from "https://deno.land/std@v0.56.0/fmt/colors.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -48,7 +48,7 @@ export namespace Drash {
    *
    * @property string version
    */
-  export const version: string = "v1.0.4";
+  export const version: string = "v1.0.5";
 
   export namespace Compilers {
     export class TemplateEngine extends BaseTemplateEngine {}

--- a/mod.ts
+++ b/mod.ts
@@ -48,7 +48,7 @@ export namespace Drash {
    *
    * @property string version
    */
-  export const version: string = "v1.0.3";
+  export const version: string = "v1.0.4";
 
   export namespace Compilers {
     export class TemplateEngine extends BaseTemplateEngine {}

--- a/tests/unit/mod_test.ts
+++ b/tests/unit/mod_test.ts
@@ -1,5 +1,10 @@
 import members from "../members.ts";
 
+members.test("mod_test.ts | Drash.version: must be current version", () => {
+  const version = members.Drash.version;
+  members.assert.equals(version, "v1.0.5");
+});
+
 members.test("mod_test.ts | Drash.addMember(): class", () => {
   class SomeCoolService {
     public coolify() {
@@ -91,9 +96,4 @@ members.test("mod_test.ts | Drash.addLogger(): names must be unique", () => {
     members.Drash.Exceptions.NameCollisionException,
     'Loggers must be unique: "TestLogger" was already added.',
   );
-});
-
-members.test("mod_test.ts | Drash.version: must be current version", () => {
-  const version = members.Drash.version;
-  members.assert.equals(version, "v1.0.4");
 });

--- a/tests/unit/mod_test.ts
+++ b/tests/unit/mod_test.ts
@@ -95,5 +95,5 @@ members.test("mod_test.ts | Drash.addLogger(): names must be unique", () => {
 
 members.test("mod_test.ts | Drash.version: must be current version", () => {
   const version = members.Drash.version;
-  members.assert.equals(version, "v1.0.3");
+  members.assert.equals(version, "v1.0.4");
 });


### PR DESCRIPTION
This PR removes the integration tests. This PR has the v1.0.4 tag as well. When this merges into master, I will push the v1.0.5 tag.