### PR TITLE
[fix-bumper-ci] Using hard coded version values

### DIFF
--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -1,7 +1,7 @@
 name: bumper
 on:
   schedule:
-    - cron: '45 0 * * *'
+    - cron: '5 1 * * *'
 
 jobs:
   update-dep:

--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -12,13 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Echo env Vars
+        run: echo $DENO_VERSION $DMM_VERSION
+
       - name: Install Deno
         uses: denolib/setup-deno@master
         with:
-          deno-version: $DENO_VERSION
+          deno-version: v1.0.5
 
       - name: Update Dependencies
-        run: deno run --allow-net --allow-read=deps.ts --allow-write=deps.ts https://deno.land/x/dmm@v$DMM_VERSION/mod.ts update
+        run: deno run --allow-net --allow-read=deps.ts --allow-write=deps.ts https://deno.land/x/dmm@v1.0.3/mod.ts update
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2


### PR DESCRIPTION
CI uses hard coded values to see if its a problem with the environmental variables. Also echos out that vars to see if they are defined in the current context