### PR TITLE
Fix bumper ci

### DIFF
--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Echo env Vars
-        run: echo $DENO_VERSION $DMM_VERSION
-
       - name: Install Deno
         uses: denolib/setup-deno@master
         with:

--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -5,9 +5,10 @@ on:
 
 jobs:
   update-dep:
-    env:
-      DENO_VERSION: v1.0.5
-      DMM_VERSION: 1.0.3
+    strategy:
+      matrix:
+        deno: ["1.0.5"]
+        dmm: ["1.0.3"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,10 +16,10 @@ jobs:
       - name: Install Deno
         uses: denolib/setup-deno@master
         with:
-          deno-version: v1.0.5
+          deno-version: ${{ matrix.deno }}
 
       - name: Update Dependencies
-        run: deno run --allow-net --allow-read=deps.ts --allow-write=deps.ts https://deno.land/x/dmm@v1.0.4/mod.ts update
+        run: deno run --allow-net --allow-read=deps.ts --allow-write=deps.ts https://deno.land/x/dmm@v${{ matrix.dmm }}/mod.ts update
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2

--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -1,7 +1,7 @@
 name: bumper
 on:
   schedule:
-    - cron: '5 1 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   update-dep:
@@ -21,7 +21,7 @@ jobs:
           deno-version: v1.0.5
 
       - name: Update Dependencies
-        run: deno run --allow-net --allow-read=deps.ts --allow-write=deps.ts https://deno.land/x/dmm@v1.0.3/mod.ts update
+        run: deno run --allow-net --allow-read=deps.ts --allow-write=deps.ts https://deno.land/x/dmm@v1.0.4/mod.ts update
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2


### PR DESCRIPTION
Tested and this works. If you would rather have the versions as environmental variables then we would need investigate why they it isn't working. Oddly, if you add a new run block, and echo the vars - they show correctly. But it works at the moment and it doesn't come off as bad practice (but env vars would be ideal of course)

I'm fine with either way