### PR TITLE
Issue #242 create app windows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,6 @@ jobs:
         run: deno test tests/test.ts --config tsconfig.json --allow-net
 
       - name: Create APP
-        if: ${{ startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos') }}
         run: deno test tests/create_app_test.ts --allow-read --allow-write --allow-run
 
   linter:

--- a/create_app.ts
+++ b/create_app.ts
@@ -61,9 +61,7 @@ function showHelp() {
     "\n" +
     "    deno run --allow-read --allow-run --allow-write https://deno.land/x/drash/create_app.ts --api" +
     "\n";
-  Deno.run({
-    cmd: ["echo", helpMessage],
-  });
+  console.info(helpMessage)
 }
 
 /**
@@ -73,9 +71,7 @@ function showHelp() {
  * @param {string} message Message to show in the console. Required.
  */
 function writeFileWrittenOrCreatedMessage(message: string) {
-  Deno.run({
-    cmd: ["echo", green(message)],
-  });
+  console.info(green(message))
 }
 
 /**
@@ -92,14 +88,11 @@ function sendThankYouMessage() {
     : wantsWebApp && wantsVue
     ? "Your web app with Vue "
     : "";
-  Deno.run({
-    cmd: [
-      "echo",
-      whatUserWanted + "has been created at " + cwd +
-      ".\nThank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
-      notesForUser.join("\n"),
-    ],
-  });
+  console.info(
+    whatUserWanted + "has been created at " + cwd +
+    ".\nThank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
+    notesForUser.join("\n")
+  )  
 }
 
 function buildTheBaseline() {
@@ -182,41 +175,20 @@ function buildForAPI() {
 
 // Requirement: Now allowed to ask for an API AND Web App
 if (wantsApi && wantsWebApp) {
-  Deno.run({
-    cmd: [
-      "echo",
-      red(
-        "--web-app and --api options are now allowed to be used together. Use the --help option for more information.",
-      ),
-    ],
-  });
+  console.error(red("--web-app and --api options are now allowed to be used together. Use the --help option for more information."))
   Deno.exit(1);
 }
 
 // Requirement: One main argument is required
 const tooFewArgs = !wantsHelp && !wantsWebApp && !wantsApi;
 if (tooFewArgs) {
-  Deno.run({
-    cmd: [
-      "echo",
-      red(
-        "Too few options were given. Use the --help option for more information.",
-      ),
-    ],
-  });
+  console.error(red("Too few options were given. Use the --help option for more information."))
   Deno.exit(1);
 }
 
 // Requirement: --with-vue is only allowed to be used with --web-app. Helps for user error mainly
 if (wantsVue && !wantsWebApp) {
-  Deno.run({
-    cmd: [
-      "echo",
-      red(
-        "The --with-vue option is only allowed for use with a web app. Use the --help option for more information.",
-      ),
-    ],
-  });
+  console.error(red("The --with-vue option is only allowed for use with a web app. Use the --help option for more information."))
   Deno.exit(1);
 }
 

--- a/create_app.ts
+++ b/create_app.ts
@@ -4,12 +4,13 @@ const wantsHelp = (args.find((arg) => arg === "--help") !== undefined);
 const wantsWebApp = (args.find((arg) => arg === "--web-app") !== undefined);
 const wantsApi = (args.find((arg) => arg === "--api") !== undefined);
 const wantsVue = (args.find((arg) => arg === "--with-vue") !== undefined);
-const cwd = Deno.cwd();
+const cwd = Deno.realPathSync(".");
 // strip this file name from the path and add the link to the boilerplate dir
-const boilerPlateDir = (import.meta.url.slice(0, -13)).substring(5) +
-  "console/create_app";
-//                                  ^^^^^^^^              ^^^^            ^^^^^^^
-//                Remove the file name from the path   Strip "file://"  Add boiler plate dir
+const pathToScriptRoot = import.meta.url.slice(0, -13) // Remove this script name: ".../deno-drash/"
+const boilerPlateDir = Deno.build.os === "windows" ?
+  pathToScriptRoot.substring(8) + "console/create_app" // Remove characters that would error, for example, removing "file:///" for windows
+  :
+  pathToScriptRoot.substring(5) + "console/create_app"
 const notesForUser: string[] = [];
 
 //////////////////////////////////////////////////////////////////////////////

--- a/create_app.ts
+++ b/create_app.ts
@@ -6,11 +6,10 @@ const wantsApi = (args.find((arg) => arg === "--api") !== undefined);
 const wantsVue = (args.find((arg) => arg === "--with-vue") !== undefined);
 const cwd = Deno.realPathSync(".");
 // strip this file name from the path and add the link to the boilerplate dir
-const pathToScriptRoot = import.meta.url.slice(0, -13) // Remove this script name: ".../deno-drash/"
-const boilerPlateDir = Deno.build.os === "windows" ?
-  pathToScriptRoot.substring(8) + "console/create_app" // Remove characters that would error, for example, removing "file:///" for windows
-  :
-  pathToScriptRoot.substring(5) + "console/create_app"
+const pathToScriptRoot = import.meta.url.slice(0, -13); // Remove this script name: ".../deno-drash/"
+const boilerPlateDir = Deno.build.os === "windows"
+  ? pathToScriptRoot.substring(8) + "console/create_app" // Remove characters that would error, for example, removing "file:///" for windows
+  : pathToScriptRoot.substring(5) + "console/create_app";
 const notesForUser: string[] = [];
 
 //////////////////////////////////////////////////////////////////////////////
@@ -62,7 +61,7 @@ function showHelp() {
     "\n" +
     "    deno run --allow-read --allow-run --allow-write https://deno.land/x/drash/create_app.ts --api" +
     "\n";
-  console.info(helpMessage)
+  console.info(helpMessage);
 }
 
 /**
@@ -72,7 +71,7 @@ function showHelp() {
  * @param {string} message Message to show in the console. Required.
  */
 function writeFileWrittenOrCreatedMessage(message: string) {
-  console.info(green(message))
+  console.info(green(message));
 }
 
 /**
@@ -91,9 +90,9 @@ function sendThankYouMessage() {
     : "";
   console.info(
     whatUserWanted + "has been created at " + cwd +
-    ".\nThank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
-    notesForUser.join("\n")
-  )  
+      ".\nThank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
+      notesForUser.join("\n"),
+  );
 }
 
 function buildTheBaseline() {
@@ -176,20 +175,32 @@ function buildForAPI() {
 
 // Requirement: Now allowed to ask for an API AND Web App
 if (wantsApi && wantsWebApp) {
-  console.error(red("--web-app and --api options are now allowed to be used together. Use the --help option for more information."))
+  console.error(
+    red(
+      "--web-app and --api options are now allowed to be used together. Use the --help option for more information.",
+    ),
+  );
   Deno.exit(1);
 }
 
 // Requirement: One main argument is required
 const tooFewArgs = !wantsHelp && !wantsWebApp && !wantsApi;
 if (tooFewArgs) {
-  console.error(red("Too few options were given. Use the --help option for more information."))
+  console.error(
+    red(
+      "Too few options were given. Use the --help option for more information.",
+    ),
+  );
   Deno.exit(1);
 }
 
 // Requirement: --with-vue is only allowed to be used with --web-app. Helps for user error mainly
 if (wantsVue && !wantsWebApp) {
-  console.error(red("The --with-vue option is only allowed for use with a web app. Use the --help option for more information."))
+  console.error(
+    red(
+      "The --with-vue option is only allowed for use with a web app. Use the --help option for more information.",
+    ),
+  );
   Deno.exit(1);
 }
 


### PR DESCRIPTION
Fixes #242 

**Description**

* Allowed the CI to run tests for windows

* Fixed one issue for windows, with Deno.run. `cmd: ["echo", ...` doesn't work on windows, the logic would need to be `cmd: ["cmd", "/c", "echo" ...]`. But i realised a subprocess isnt even needed - logging the data is enough

* Fixed the 2nd issue for windows, where the `boilerPlateDir` (using `import.meta.url`) was incorrect for windows users. 