### PR TITLE
Issue #232 improve create app tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,7 +36,9 @@ jobs:
           deno test --allow-all --config tsconfig.json tests/integration/app_3004_pretty_links/tests.ts
 
       - name: Create APP
-        run: deno test tests/cli/create_app_test.ts --allow-read --allow-write --allow-run
+        run: |
+          deno cache mod.ts
+          deno test tests/cli/create_app_test.ts --allow-read --allow-write --allow-run
 
   linter:
     strategy:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create APP
         run: |
-          deno cache mod.ts
+          deno cache create_app.ts
           deno test tests/cli/create_app_test.ts --allow-read --allow-write --allow-run
 
   linter:

--- a/create_app.ts
+++ b/create_app.ts
@@ -79,18 +79,19 @@ function writeFileWrittenOrCreatedMessage(message: string) {
  */
 function sendThankYouMessage() {
   notesForUser.push(
-    "Run your application: deno run --allow-net --allow-read app.ts",
+      "To run your application:",
+      "    deno run --allow-net --allow-read app.ts",
   );
   const whatUserWanted = wantsApi
-    ? "Your API "
+    ? "Your Drash API project "
     : wantsWebApp && !wantsVue
-    ? "Your web app "
+    ? "Your Drash web app project "
     : wantsWebApp && wantsVue
-    ? "Your web app with Vue "
+    ? "Your Drash web app project with Vue "
     : "";
   console.info(
-    whatUserWanted + "has been created at " + cwd +
-      ".\nThank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
+    whatUserWanted + "has been created.\n" +
+      "Thank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
       notesForUser.join("\n"),
   );
 }
@@ -137,9 +138,9 @@ function buildForWebApp() {
       `${boilerPlateDir}/public/views/index_vue.html`,
       cwd + "/public/views/index.html",
     );
-    notesForUser.push("Install NPM dependencies: npm install");
+    notesForUser.push("Install NPM dependencies:\n    npm install");
     notesForUser.push(
-      "Build your Vue component with webpack: npm run buildVue",
+      "Build your Vue component with Webpack:\n    npm run buildVue",
     );
   } else {
     Deno.copyFileSync(
@@ -189,16 +190,6 @@ if (tooFewArgs) {
   console.error(
     red(
       "Too few options were given. Use the --help option for more information.",
-    ),
-  );
-  Deno.exit(1);
-}
-
-// Requirement: --with-vue is only allowed to be used with --web-app. Helps for user error mainly
-if (wantsVue && !wantsWebApp) {
-  console.error(
-    red(
-      "The --with-vue option is only allowed for use with a web app. Use the --help option for more information.",
     ),
   );
   Deno.exit(1);

--- a/create_app.ts
+++ b/create_app.ts
@@ -79,8 +79,8 @@ function writeFileWrittenOrCreatedMessage(message: string) {
  */
 function sendThankYouMessage() {
   notesForUser.push(
-      "To run your application:",
-      "    deno run --allow-net --allow-read app.ts",
+    "To run your application:",
+    "    deno run --allow-net --allow-read app.ts",
   );
   const whatUserWanted = wantsApi
     ? "Your Drash API project "

--- a/tests/cli/create_app_test.ts
+++ b/tests/cli/create_app_test.ts
@@ -5,7 +5,7 @@
  * This is only for some tests
  */
 
-import { red, green } from "../../deps.ts"
+import { red, green } from "../../deps.ts";
 import members from "../members.ts";
 const tmpDirName = "tmp-dir-for-testing-create-app";
 const originalCWD = Deno.cwd();
@@ -46,7 +46,12 @@ members.test("create_app_test.ts | Script fails with no argument", async () => {
   p.close();
   const stdout = new TextDecoder("utf-8").decode(await p.output());
   const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
-  members.assertEquals(stderr, red("Too few options were given. Use the --help option for more information.") + "\n");
+  members.assertEquals(
+    stderr,
+    red(
+      "Too few options were given. Use the --help option for more information.",
+    ) + "\n",
+  );
   members.assertEquals(stdout, "");
   members.assertEquals(status.code, 1);
   members.assertEquals(status.success, false);
@@ -71,8 +76,9 @@ members.test("create_app_test.ts | Script success with the --help argument", asy
   const stdout = new TextDecoder("utf-8").decode(await p.output());
   const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
   members.assertEquals(stderr, "");
-  members.assertEquals(stdout,
-      "\n" +
+  members.assertEquals(
+    stdout,
+    "\n" +
       "A create app script for Drash\n" +
       "\n" +
       "USAGE:\n" +
@@ -96,7 +102,7 @@ members.test("create_app_test.ts | Script success with the --help argument", asy
       "    mkdir my-drash-api\n" +
       "    cd my-drash-api\n" +
       "    deno run --allow-read --allow-run --allow-write https://deno.land/x/drash/create_app.ts --api\n" +
-      "\n"
+      "\n",
   );
   members.assertEquals(status.code, 0);
   members.assertEquals(status.success, true);
@@ -124,11 +130,10 @@ members.test("create_app_test.ts | Script creates an API project with the --api 
   const stdout = new TextDecoder("utf-8").decode(await p.output());
   const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
   members.assertEquals(stderr, "");
-  const assertedStdout =
-      "Your Drash API project has been created.\n" +
-      "Thank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
-      "To run your application:\n" +
-      "    deno run --allow-net --allow-read app.ts\n";
+  const assertedStdout = "Your Drash API project has been created.\n" +
+    "Thank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
+    "To run your application:\n" +
+    "    deno run --allow-net --allow-read app.ts\n";
   members.assertEquals(stdout, assertedStdout);
   members.assertEquals(status.code, 0);
   members.assertEquals(status.success, true);
@@ -205,11 +210,12 @@ members.test("create_app_test.ts | Script creates a web app with the --web-app a
   const stdout = new TextDecoder("utf-8").decode(await p.output());
   const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
   members.assertEquals(stderr, "");
-  members.assertEquals(stdout,
-      "Your Drash web app project has been created.\n" +
+  members.assertEquals(
+    stdout,
+    "Your Drash web app project has been created.\n" +
       "Thank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
       "To run your application:\n" +
-      "    deno run --allow-net --allow-read app.ts\n"
+      "    deno run --allow-net --allow-read app.ts\n",
   );
   members.assertEquals(status.code, 0);
   members.assertEquals(status.success, true);
@@ -311,15 +317,16 @@ members.test("create_app_test.ts | Script creates a web app with vue with the --
   const stdout = new TextDecoder("utf-8").decode(await p.output());
   const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
   members.assertEquals(stderr, "");
-  members.assertEquals(stdout,
-      "Your Drash web app project with Vue has been created.\n" +
+  members.assertEquals(
+    stdout,
+    "Your Drash web app project with Vue has been created.\n" +
       "Thank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
       "Install NPM dependencies:\n" +
       "    npm install\n" +
       "Build your Vue component with Webpack:\n" +
       "    npm run buildVue\n" +
       "To run your application:\n" +
-      "    deno run --allow-net --allow-read app.ts\n"
+      "    deno run --allow-net --allow-read app.ts\n",
   );
   members.assertEquals(status.code, 0);
   members.assertEquals(status.success, true);
@@ -427,7 +434,12 @@ members.test("create_app_test.ts | Script fails if --api and --web-app are speci
   p.close();
   const stdout = new TextDecoder("utf-8").decode(await p.output());
   const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
-  members.assertEquals(stderr, red("--web-app and --api options are now allowed to be used together. Use the --help option for more information.") + "\n");
+  members.assertEquals(
+    stderr,
+    red(
+      "--web-app and --api options are now allowed to be used together. Use the --help option for more information.",
+    ) + "\n",
+  );
   members.assertEquals(stdout, "");
   members.assertEquals(status.code, 1);
   members.assertEquals(status.success, false);

--- a/tests/cli/create_app_test.ts
+++ b/tests/cli/create_app_test.ts
@@ -5,6 +5,7 @@
  * This is only for some tests
  */
 
+import { red, green } from "../../deps.ts"
 import members from "../members.ts";
 const tmpDirName = "tmp-dir-for-testing-create-app";
 const originalCWD = Deno.cwd();
@@ -28,10 +29,6 @@ const fileExists = async (filename: string): Promise<boolean> => {
   }
 };
 
-/**
- * File requires the following flags: --allow-read, --allow-write, --allow-run
- */
-
 members.test("create_app_test.ts | Script fails with no argument", async () => {
   const p = await Deno.run({
     cmd: [
@@ -42,9 +39,15 @@ members.test("create_app_test.ts | Script fails with no argument", async () => {
       "--allow-run",
       "create_app.ts",
     ],
+    stdout: "piped",
+    stderr: "piped",
   });
   const status = await p.status();
-  await p.close();
+  p.close();
+  const stdout = new TextDecoder("utf-8").decode(await p.output());
+  const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+  members.assertEquals(stderr, red("Too few options were given. Use the --help option for more information.") + "\n");
+  members.assertEquals(stdout, "");
   members.assertEquals(status.code, 1);
   members.assertEquals(status.success, false);
 });
@@ -60,9 +63,41 @@ members.test("create_app_test.ts | Script success with the --help argument", asy
       "create_app.ts",
       "--help",
     ],
+    stdout: "piped",
+    stderr: "piped",
   });
   const status = await p.status();
-  await p.close();
+  p.close();
+  const stdout = new TextDecoder("utf-8").decode(await p.output());
+  const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+  members.assertEquals(stderr, "");
+  members.assertEquals(stdout,
+      "\n" +
+      "A create app script for Drash\n" +
+      "\n" +
+      "USAGE:\n" +
+      "    deno run --allow-read --allow-run create_app.ts [OPTIONS]\n" +
+      "    deno run --allow-read --allow-run https://deno.land/x/drash/create_app.ts [OPTIONS]\n" +
+      "\n" +
+      "OPTIONS:\n" +
+      "The --api and --web-app options cannot be used together.\n" +
+      "\n" +
+      "    --api\n" +
+      "        Creates the file structure and content for a Drash API.\n" +
+      "\n" +
+      "    --web-app\n" +
+      "        Creates the file structure and content for a Drash Web App.\n" +
+      "\n" +
+      "    --web-app --with-vue\n" +
+      "        Creates the file structure and content for a Drash Web App.\n" +
+      "        This options requires Node and npm because it uses Vue and webpack.\n" +
+      "\n" +
+      "EXAMPLE USAGE:\n" +
+      "    mkdir my-drash-api\n" +
+      "    cd my-drash-api\n" +
+      "    deno run --allow-read --allow-run --allow-write https://deno.land/x/drash/create_app.ts --api\n" +
+      "\n"
+  );
   members.assertEquals(status.code, 0);
   members.assertEquals(status.success, true);
 });
@@ -81,9 +116,20 @@ members.test("create_app_test.ts | Script creates an API project with the --api 
       "../create_app.ts",
       "--api",
     ],
+    stdout: "piped",
+    stderr: "piped",
   });
   const status = await p.status();
-  await p.close();
+  p.close();
+  const stdout = new TextDecoder("utf-8").decode(await p.output());
+  const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+  members.assertEquals(stderr, "");
+  const assertedStdout =
+      "Your Drash API project has been created.\n" +
+      "Thank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
+      "To run your application:\n" +
+      "    deno run --allow-net --allow-read app.ts\n";
+  members.assertEquals(stdout, assertedStdout);
   members.assertEquals(status.code, 0);
   members.assertEquals(status.success, true);
   // assert each file and it's content are correct
@@ -133,6 +179,7 @@ members.test("create_app_test.ts | Script creates an API project with the --api 
     Deno.readFileSync("tests/resources/home_resource_test.ts"),
   );
   members.assertEquals(boilerPlateFile, copiedFile);
+  // Remove the created directory
   Deno.chdir(originalCWD);
   Deno.removeSync(tmpDirName, { recursive: true });
 });
@@ -150,9 +197,20 @@ members.test("create_app_test.ts | Script creates a web app with the --web-app a
       "../create_app.ts",
       "--web-app",
     ],
+    stdout: "piped",
+    stderr: "piped",
   });
   const status = await p.status();
-  await p.close();
+  p.close();
+  const stdout = new TextDecoder("utf-8").decode(await p.output());
+  const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+  members.assertEquals(stderr, "");
+  members.assertEquals(stdout,
+      "Your Drash web app project has been created.\n" +
+      "Thank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
+      "To run your application:\n" +
+      "    deno run --allow-net --allow-read app.ts\n"
+  );
   members.assertEquals(status.code, 0);
   members.assertEquals(status.success, true);
   // assert each file and it's content are correct
@@ -245,9 +303,24 @@ members.test("create_app_test.ts | Script creates a web app with vue with the --
       "--web-app",
       "--with-vue",
     ],
+    stdout: "piped",
+    stderr: "piped",
   });
   const status = await p.status();
-  await p.close();
+  p.close();
+  const stdout = new TextDecoder("utf-8").decode(await p.output());
+  const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+  members.assertEquals(stderr, "");
+  members.assertEquals(stdout,
+      "Your Drash web app project with Vue has been created.\n" +
+      "Thank you for using Drash's create app script, we hope you enjoy your newly built project!\n" +
+      "Install NPM dependencies:\n" +
+      "    npm install\n" +
+      "Build your Vue component with Webpack:\n" +
+      "    npm run buildVue\n" +
+      "To run your application:\n" +
+      "    deno run --allow-net --allow-read app.ts\n"
+  );
   members.assertEquals(status.code, 0);
   members.assertEquals(status.success, true);
   // assert each file and it's content are correct
@@ -335,24 +408,6 @@ members.test("create_app_test.ts | Script creates a web app with vue with the --
   Deno.removeSync(tmpDirName, { recursive: true });
 });
 
-members.test("create_app_test.ts | Script fails if --with-vue is set but --web-app isn\'t", async () => {
-  const p = await Deno.run({
-    cmd: [
-      "deno",
-      "run",
-      "--allow-read",
-      "--allow-write",
-      "--allow-run",
-      "create_app.ts",
-      "--with-vue",
-    ],
-  });
-  const status = await p.status();
-  await p.close();
-  members.assertEquals(status.code, 1);
-  members.assertEquals(status.success, false);
-});
-
 members.test("create_app_test.ts | Script fails if --api and --web-app are specified", async () => {
   const p = await Deno.run({
     cmd: [
@@ -365,9 +420,15 @@ members.test("create_app_test.ts | Script fails if --api and --web-app are speci
       "--api",
       "--web-app",
     ],
+    stdout: "piped",
+    stderr: "piped",
   });
   const status = await p.status();
-  await p.close();
+  p.close();
+  const stdout = new TextDecoder("utf-8").decode(await p.output());
+  const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+  members.assertEquals(stderr, red("--web-app and --api options are now allowed to be used together. Use the --help option for more information.") + "\n");
+  members.assertEquals(stdout, "");
   members.assertEquals(status.code, 1);
   members.assertEquals(status.success, false);
 });


### PR DESCRIPTION
Fixes #232 

**Description**

* Added assertions for stdout and stderr

* Removed one test because it isn't actually needed and covered by the test that requires a main argument (a main argument is either: --help, --api or --web-app and not --with-vue)