### PR TITLE
Issue #269 get formdata body

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -98,9 +98,9 @@ export class Request extends ServerRequest {
    * @param string input
    *     The name of the file to get.
    *
-   * @return FormFile
+   * @return FormFile|undefined
    */
-  public getBodyFile(input: string): FormFile {
+  public getBodyFile(input: string): FormFile|undefined {
     return this.parsed_body.data.file(input);
   }
 

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -100,7 +100,7 @@ export class Request extends ServerRequest {
    *
    * @return FormFile|undefined
    */
-  public getBodyFile(input: string): FormFile|undefined {
+  public getBodyFile(input: string): FormFile | undefined {
     return this.parsed_body.data.file(input);
   }
 

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -113,7 +113,7 @@ export class Request extends ServerRequest {
   public getBodyParam(input: string): string | null {
     let param;
     if (typeof this.parsed_body.data.value === "function") { // For when multipart/form-data
-      param = this.parsed_body.data.value(input)
+      param = this.parsed_body.data.value(input);
     } else { // Anything else
       param = this.parsed_body.data[input];
     }

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -98,9 +98,9 @@ export class Request extends ServerRequest {
    * @param string input
    *     The name of the file to get.
    *
-   * @return unknown
+   * @return FormFile
    */
-  public getBodyFile(input: string): string {
+  public getBodyFile(input: string): FormFile {
     return this.parsed_body.data.file(input);
   }
 

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -92,29 +92,31 @@ export class Request extends ServerRequest {
 
   /**
    * @description
-   *     Parse this request's body as `multipart/form-data` and get the
-   *     requested input.
+   *     Get the requested file from the body of a multipart/form-data
+   *     request, by it's name.
    *
    * @param string input
-   *     The filename of the file to get ??? (clarify).
+   *     The name of the file to get.
    *
    * @return unknown
    */
   public getBodyFile(input: string): string {
-    return this.parsed_body.data.value(input);
+    return this.parsed_body.data.file(input);
   }
 
   /**
    * @description
    *     Get the value of one of this request's body params by its input name.
-   *     First, check the Content-Type of the request so that we know how to
-   *     parse the body. Then parse the body accordingly and retrieve the
-   *     requested value.
    *
    * @return string|null
    */
   public getBodyParam(input: string): string | null {
-    const param = this.parsed_body.data[input];
+    let param;
+    if (typeof this.parsed_body.data.value === "function") { // For when multipart/form-data
+      param = this.parsed_body.data.value(input)
+    } else { // Anything else
+      param = this.parsed_body.data[input];
+    }
     if (param) {
       return param;
     }

--- a/tests/integration/app_3000_resources/files_resource_test.ts
+++ b/tests/integration/app_3000_resources/files_resource_test.ts
@@ -7,7 +7,7 @@ Rhum.testPlan("files_resource_test.ts", () => {
       let response;
 
       let formData = new FormData();
-      formData.append("file_1", "John");
+      formData.append("value_1", "John");
 
       response = await fetch("http://localhost:3000/files", {
         method: "POST",

--- a/tests/integration/app_3000_resources/resources/files_resource.ts
+++ b/tests/integration/app_3000_resources/resources/files_resource.ts
@@ -4,7 +4,7 @@ export default class FilesResource extends Drash.Http.Resource {
   static paths = ["/files"];
 
   public async POST() {
-    this.response.body = this.request.getBodyFile("file_1") ?? null;
+    this.response.body = this.request.getBodyParam("value_1") ?? null;
     return this.response;
   }
 

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -184,16 +184,16 @@ function getBodyFileTests() {
     const request = new Drash.Http.Request(serverRequest);
     const o = await Deno.open(path.resolve("./tests/data/sample_1.txt"));
     const form = await request.parseBodyAsMultipartFormData(
-        o,
-        "--------------------------434049563556637648550474",
-        128
+      o,
+      "--------------------------434049563556637648550474",
+      128,
     );
     const pb: Drash.Interfaces.ParsedRequestBody = {
       content_type: "multipart/form-data",
-      data: form
+      data: form,
     };
     request.parsed_body = pb;
-    const file = request.getBodyFile("file")
+    const file = request.getBodyFile("file");
     Rhum.asserts.assertEquals(file.filename, "tsconfig.json");
     Rhum.asserts.assertEquals(file.type, "application/octet-stream");
     Rhum.asserts.assertEquals(file.size, 233);
@@ -202,28 +202,28 @@ function getBodyFileTests() {
       Rhum.asserts.assertEquals(content.constructor === Uint8Array, true);
     } else {
       // The content of the file should be set!
-      Rhum.asserts.assertEquals(true, false)
+      Rhum.asserts.assertEquals(true, false);
     }
-    await o.close()
-  })
+    await o.close();
+  });
 
   Rhum.testCase("Returns ??? if the file does not exist", async () => {
     const serverRequest = members.mockRequest();
     const request = new Drash.Http.Request(serverRequest);
     const o = await Deno.open(path.resolve("./tests/data/sample_1.txt"));
     const form = await request.parseBodyAsMultipartFormData(
-        o,
-        "--------------------------434049563556637648550474",
-        128
+      o,
+      "--------------------------434049563556637648550474",
+      128,
     );
     const pb: Drash.Interfaces.ParsedRequestBody = {
       content_type: "multipart/form-data",
-      data: form
+      data: form,
     };
     request.parsed_body = pb;
-    const file = request.getBodyFile("dontExist")
+    const file = request.getBodyFile("dontExist");
     Rhum.asserts.assertEquals(file, undefined);
-    await o.close()
+    await o.close();
   });
 }
 
@@ -265,23 +265,26 @@ function getBodyParamTests() {
   });
 
   // Reason: `this.request.getBodyParam()` didn't work for multipart/form-data requests
-  Rhum.testCase("Returns the value for the parameter when it exists and request is multipart/form-data", async () => {
-    const serverRequest = members.mockRequest();
-    const request = new Drash.Http.Request(serverRequest);
-    const o = await Deno.open(path.resolve("./tests/data/sample_1.txt"));
-    const form = await request.parseBodyAsMultipartFormData(
+  Rhum.testCase(
+    "Returns the value for the parameter when it exists and request is multipart/form-data",
+    async () => {
+      const serverRequest = members.mockRequest();
+      const request = new Drash.Http.Request(serverRequest);
+      const o = await Deno.open(path.resolve("./tests/data/sample_1.txt"));
+      const form = await request.parseBodyAsMultipartFormData(
         o,
         "--------------------------434049563556637648550474",
-        128
-    );
-    const pb: Drash.Interfaces.ParsedRequestBody = {
-      content_type: "multipart/form-data",
-      data: form
-    }
-    request.parsed_body = pb;
-    Rhum.asserts.assertEquals(request.getBodyParam("foo"), "foo");
-    await o.close()
-  })
+        128,
+      );
+      const pb: Drash.Interfaces.ParsedRequestBody = {
+        content_type: "multipart/form-data",
+        data: form,
+      };
+      request.parsed_body = pb;
+      Rhum.asserts.assertEquals(request.getBodyParam("foo"), "foo");
+      await o.close();
+    },
+  );
 }
 
 function getHeaderParamTests() {

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -194,10 +194,10 @@ function getBodyFileTests() {
     };
     request.parsed_body = pb;
     const file = request.getBodyFile("file");
-    Rhum.asserts.assertEquals(file.filename, "tsconfig.json");
-    Rhum.asserts.assertEquals(file.type, "application/octet-stream");
-    Rhum.asserts.assertEquals(file.size, 233);
-    const content = file.content;
+    Rhum.asserts.assertEquals(file!.filename, "tsconfig.json");
+    Rhum.asserts.assertEquals(file!.type, "application/octet-stream");
+    Rhum.asserts.assertEquals(file!.size, 233);
+    const content = file!.content;
     if (content !== undefined) {
       Rhum.asserts.assertEquals(content.constructor === Uint8Array, true);
     } else {

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -207,7 +207,7 @@ function getBodyFileTests() {
     await o.close();
   });
 
-  Rhum.testCase("Returns ??? if the file does not exist", async () => {
+  Rhum.testCase("Returns undefined if the file does not exist", async () => {
     const serverRequest = members.mockRequest();
     const request = new Drash.Http.Request(serverRequest);
     const o = await Deno.open(path.resolve("./tests/data/sample_1.txt"));


### PR DESCRIPTION
Fixes #269 

**Description**

* Notes are seen in the issue, but I have corrected the logic for getting data. `getBodyFile` was using `.value` when it should be using `.file`. Also adjusted the return type.

* `getBodyParam` wasn't accounting for a parsed body request as multipart/form-data, so I have added extra logic to account for that.

* Re-added tests for these fixes