### PR TITLE
Add server middleware interface

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -35,6 +35,7 @@ import { Resource as BaseHttpResource } from "./src/interfaces/resource.ts";
 import { ResourcePaths as BaseResourcePaths } from "./src/interfaces/resource_paths.ts";
 import { ResponseOutput as BaseResponseOutput } from "./src/interfaces/response_output.ts";
 import { ServerConfigs as BaseServerConfigs } from "./src/interfaces/server_configs.ts";
+import { ServerMiddleware as BaseServerMiddleware } from "./src/interfaces/server_middleware.ts";
 
 // Loggers
 import { Logger as BaseLogger } from "./src/core_loggers/logger.ts";
@@ -94,6 +95,7 @@ export namespace Drash {
     export interface ResourcePaths extends BaseResourcePaths {}
     export interface ResponseOutput extends BaseResponseOutput {}
     export interface ServerConfigs extends BaseServerConfigs {}
+    export interface ServerMiddleware extends BaseServerMiddleware {}
   }
 
   export namespace Services {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -10,6 +10,7 @@ import {
   serve,
   serveTLS,
 } from "../../deps.ts";
+import { ServerMiddleware } from "../interfaces/server_middleware.ts";
 
 interface IRequestOptions {
   default_response_content_type: string | undefined;
@@ -94,21 +95,9 @@ export class Server {
    * @description
    *     A property to hold middleware.
    *
-   * @property middleware
+   * @property ServerMiddleware middleware
    */
-  protected middleware: {
-    before_request?: Array<
-      | ((request: Drash.Http.Request) => Promise<void>)
-      | ((request: Drash.Http.Request) => void)
-    >;
-    after_request?: Array<
-      | ((
-        request: Drash.Http.Request,
-        response: Drash.Http.Response,
-      ) => Promise<void>)
-      | ((request: Drash.Http.Request, response: Drash.Http.Response) => void)
-    >;
-  } = {};
+  protected middleware: ServerMiddleware = {};
 
   /**
    * @description

--- a/src/interfaces/server_middleware.ts
+++ b/src/interfaces/server_middleware.ts
@@ -35,14 +35,14 @@ import { Drash } from "../../mod.ts";
  */
 export interface ServerMiddleware {
   before_request?: Array<
-      | ((request: Drash.Http.Request) => Promise<void>)
-      | ((request: Drash.Http.Request) => void)
-      >;
+    | ((request: Drash.Http.Request) => Promise<void>)
+    | ((request: Drash.Http.Request) => void)
+  >;
   after_request?: Array<
-      | ((
+    | ((
       request: Drash.Http.Request,
       response: Drash.Http.Response,
-  ) => Promise<void>)
-      | ((request: Drash.Http.Request, response: Drash.Http.Response) => void)
-      >;
+    ) => Promise<void>)
+    | ((request: Drash.Http.Request, response: Drash.Http.Response) => void)
+  >;
 }

--- a/src/interfaces/server_middleware.ts
+++ b/src/interfaces/server_middleware.ts
@@ -1,0 +1,48 @@
+import { Drash } from "../../mod.ts";
+
+/**
+ * @memberof Drash.Interfaces
+ * @interface ServerMiddleware
+ *
+ * @description
+ *     before_request: Array<Function>
+ *
+ *         An array of functions that take a Drash.Http.Request as a parameter.
+ *         Method can be async.
+ *
+ *     after_request: Array<Function>
+ *
+ *         An array of functions that take in a Drash.Http.Request as the first
+ *         parameter, and a Drash.Http.Response as the second parameter.
+ *         Method can be async.
+ *
+ * @example
+ * function beforeRequestMiddleware (request: Drash.Http.Request): void {
+ *   ...
+ * }
+ * async function afterRequestMiddleware (
+ *   request: Drash.Http.Request,
+ *   response: Drash.Http.Response
+ * ): Promise<void> {
+ *   ...
+ * }
+ * const server = new Drash.Http.Server({
+ *   middleware: {
+ *     before_request: [beforeRequestMiddleware],
+ *     afterRequest: [afterRequestMiddleware]
+ *   }
+ * }
+ */
+export interface ServerMiddleware {
+  before_request?: Array<
+      | ((request: Drash.Http.Request) => Promise<void>)
+      | ((request: Drash.Http.Request) => void)
+      >;
+  after_request?: Array<
+      | ((
+      request: Drash.Http.Request,
+      response: Drash.Http.Response,
+  ) => Promise<void>)
+      | ((request: Drash.Http.Request, response: Drash.Http.Response) => void)
+      >;
+}


### PR DESCRIPTION
Fixes #276 

**Description**

* Moved type for middleware into it's own file

* Server#middleware now uses the interface

* Added the interface to `Drash.Interfaces`