### PR TITLE
Address todo tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ package-lock.json
 .sass-cache
 tmp/*
 node_modules
+.idea
 
 # exceptions
 !.gitkeep

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -325,6 +325,13 @@ export class Request extends ServerRequest {
         ) {
           maxMemory = options.memory_allocation.multipart_form_data;
         }
+        console.log("[parseBody]")
+        console.log("this.original_request.body:")
+        console.log(this.original_request.body)
+        console.log("boundary:")
+        console.log(boundary)
+        console.log("maxMemory:")
+        console.log(maxMemory)
         ret.data = await this.parseBodyAsMultipartFormData(
           this.original_request.body,
           boundary,
@@ -332,6 +339,8 @@ export class Request extends ServerRequest {
         );
         ret.content_type = "multipart/form-data";
       } catch (error) {
+        console.error("Error when parsing multipart data: ");
+        console.error(error);
         throw new Error(
           `Error reading request body as multipart/form-data.`,
         );
@@ -424,7 +433,9 @@ export class Request extends ServerRequest {
       maxMemory *= 1024 * 1024;
     }
     const mr = new MultipartReader(body, boundary);
+    console.log("100% the code below will fail...");
     const ret = await mr.readForm(maxMemory);
+    console.log("Omg it didnt fail!? WHAT?!?");
     // console.log(ret);
     return ret;
   }

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -325,13 +325,6 @@ export class Request extends ServerRequest {
         ) {
           maxMemory = options.memory_allocation.multipart_form_data;
         }
-        console.log("[parseBody]")
-        console.log("this.original_request.body:")
-        console.log(this.original_request.body)
-        console.log("boundary:")
-        console.log(boundary)
-        console.log("maxMemory:")
-        console.log(maxMemory)
         ret.data = await this.parseBodyAsMultipartFormData(
           this.original_request.body,
           boundary,
@@ -339,8 +332,6 @@ export class Request extends ServerRequest {
         );
         ret.content_type = "multipart/form-data";
       } catch (error) {
-        console.error("Error when parsing multipart data: ");
-        console.error(error);
         throw new Error(
           `Error reading request body as multipart/form-data.`,
         );
@@ -433,9 +424,7 @@ export class Request extends ServerRequest {
       maxMemory *= 1024 * 1024;
     }
     const mr = new MultipartReader(body, boundary);
-    console.log("100% the code below will fail...");
     const ret = await mr.readForm(maxMemory);
-    console.log("Omg it didnt fail!? WHAT?!?");
     // console.log(ret);
     return ret;
   }

--- a/tests/members.ts
+++ b/tests/members.ts
@@ -33,7 +33,11 @@ function mockRequest(url = "/", method = "get", options?: any): any {
       }
     }
     if (options.body) {
-      request.headers.set("Content-Length", options.body.length.toString());
+      try {
+        request.headers.set("Content-Length", options.body.length.toString());
+      } catch (err) {
+        // ... you *shall* pass
+      }
       request.r = new BufReader(options.body);
     }
   }

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -512,7 +512,6 @@ function parseBodyTests() {
   //
   // })
 
-  // TODO(ebebbington) Fails, cannot parse as JSON. Find out how to send the correct data
   Rhum.testCase("Can correctly parse as application/json", async () => {
     const encodedBody = new TextEncoder().encode(JSON.stringify({
       name: "John",

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -3,6 +3,8 @@ import members from "../../members.ts";
 import { Drash } from "../../../mod.ts";
 const encoder = new TextEncoder();
 
+// Taken  from https://github.com/denoland/deno/blob/2da084058397efd6f517ba98c9882760ec0a7bd6/cli/tests/unit/fetch_test.ts#L261
+// It's how Deno test their multipart tests
 const files = [
   {
     // prettier-ignore

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -539,55 +539,55 @@ function parseBodyTests() {
   );
 
   // TODO(ebebbington) Leaving out for the time being until a way is figured out
-  Rhum.testCase("Correctly parses multipart/form-data", async () => {
-    // Need to set the body of the original request for parseBody to work when it calls parseBodyAsMultipartFormData
-    const o = await Deno.open(path.resolve("./tests/data/sample_1.txt"));
-    const boundary = "--------------------------434049563556637648550474";
-    const formOne = await new Drash.Http.Request(members.mockRequest())
-      .parseBodyAsMultipartFormData( // method 1
-        o,
-        boundary,
-        128,
-      );
-    const formTwo = new FormData(); // method 2
-    formTwo.append("field", "value");
-    for (const file of files) {
-      formTwo.append(
-        file.name,
-        new Blob([file.content], { type: file.type }),
-        file.fileName,
-      );
-    }
-    let originalRequest = members.mockRequest("/orig", "post", {
-      body: o,
-    });
-    const newRequest = new Drash.Http.Request(originalRequest);
-    newRequest.headers.set(
-      "Content-Type",
-      "multipart/form-data; boundary=" + boundary,
-    ); // Needed since the method gets boundary from header
-    newRequest.headers.set("Content-Length", "883"); // Tells parseBody that this request has a body
-    // Send request
-    console.log("start");
-    /**
-     * Feel free to add the below logging before `await this.parseMultipartFormDataBody` in `parseBody()`:
-     * console.log("[parseBody]")
-     * console.log("this.original_request.body:")
-     * console.log(this.original_request.body)
-     * console.log("boundary:")
-     * console.log(boundary)
-     * console.log("maxMemory:")
-     * console.log(maxMemory)
-     *
-     * The problem is inside the above method, `mr.readForm` is throwing the error: UnexpectedEof
-     * I have a feeling the  `this.original_request.body` isn't what is expected, as if we replace
-     * `body` in that method with `await Deno.open(path.resolve("./tests/data/sample_1.txt"))`, it
-     * works - which makes no sense
-     */
-    const parsedBodyResult = await newRequest.parseBody();
-    Rhum.asserts.assertEquals(true, false);
-    await o.close();
-  });
+  // Rhum.testCase("Correctly parses multipart/form-data", async () => {
+  //   // Need to set the body of the original request for parseBody to work when it calls parseBodyAsMultipartFormData
+  //   const o = await Deno.open(path.resolve("./tests/data/sample_1.txt"));
+  //   const boundary = "--------------------------434049563556637648550474";
+  //   const formOne = await new Drash.Http.Request(members.mockRequest())
+  //     .parseBodyAsMultipartFormData( // method 1
+  //       o,
+  //       boundary,
+  //       128,
+  //     );
+  //   const formTwo = new FormData(); // method 2
+  //   formTwo.append("field", "value");
+  //   for (const file of files) {
+  //     formTwo.append(
+  //       file.name,
+  //       new Blob([file.content], { type: file.type }),
+  //       file.fileName,
+  //     );
+  //   }
+  //   let originalRequest = members.mockRequest("/orig", "post", {
+  //     body: o,
+  //   });
+  //   const newRequest = new Drash.Http.Request(originalRequest);
+  //   newRequest.headers.set(
+  //     "Content-Type",
+  //     "multipart/form-data; boundary=" + boundary,
+  //   ); // Needed since the method gets boundary from header
+  //   newRequest.headers.set("Content-Length", "883"); // Tells parseBody that this request has a body
+  //   // Send request
+  //   console.log("start");
+  //   /**
+  //    * Feel free to add the below logging before `await this.parseMultipartFormDataBody` in `parseBody()`:
+  //    * console.log("[parseBody]")
+  //    * console.log("this.original_request.body:")
+  //    * console.log(this.original_request.body)
+  //    * console.log("boundary:")
+  //    * console.log(boundary)
+  //    * console.log("maxMemory:")
+  //    * console.log(maxMemory)
+  //    *
+  //    * The problem is inside the above method, `mr.readForm` is throwing the error: UnexpectedEof
+  //    * I have a feeling the  `this.original_request.body` isn't what is expected, as if we replace
+  //    * `body` in that method with `await Deno.open(path.resolve("./tests/data/sample_1.txt"))`, it
+  //    * works - which makes no sense
+  //    */
+  //   const parsedBodyResult = await newRequest.parseBody();
+  //   Rhum.asserts.assertEquals(true, false);
+  //   await o.close();
+  // });
 
   Rhum.testCase(
     "Returns the default object when no boundary was found on multipart/form-data",


### PR DESCRIPTION
Intent on re-adding commented out tests, denoted by `// TODO`. Still unable to address the one left left, but provided information for when it is looked into again