### PR TITLE
chore: Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,5 +15,6 @@ jobs:
      - run: |
           cd eggs
           export PATH="/home/runner/.deno/bin:$PATH"
+          eggs upgrade
           eggs link --key ${{ secrets.CI_NESTLAND_API_KEY }}
           eggs publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ jobs:
     steps:
      - uses: actions/checkout@v2
      - uses: denolib/setup-deno@master
-       with:
-         deno-version: v1.x
-
      - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.1.5/mod.ts
      - run: |
           cd eggs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
      - uses: actions/checkout@v2
      - uses: denolib/setup-deno@master
        with:
-         deno-version: 1.1.0
+         deno-version: v1.x
 
      - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.1.5/mod.ts
      - run: |


### PR DESCRIPTION
**Description**

Without upgrading the CLI to the latest version, there could be errors when publishing for future releases.

* Added `eggs upgrade` to upgrade the CLI after installing

**Other Notes**

Thanks so much for adding Drash to nest.land!