### PR TITLE
[tsdoc-cleanup] clean up tsdoc docblocks

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -120,7 +120,8 @@ export namespace Drash {
    * Add a member to the Members namespace. After adding a member, you can use
    * the member via Drash.Members.YourMember.doSomething().
    *
-   * @param name - The member's name which can be accessed via Drash.Members[name].
+   * @param name - The member's name which can be accessed via
+   * `Drash.Members[name]`.
    * @param member - The member.
    */
   export function addMember(name: string, member: any) {
@@ -136,7 +137,8 @@ export namespace Drash {
    * Add a logger to the Loggers namespace. After adding a logger, you can use
    * the logger via Drash.Loggers.YourLogger.doSomething().
    *
-   * @param name - The logger's name which can be accessed via Drash.Members[name].
+   * @param name - The logger's name which can be accessed via
+   * `Drash.Members[name]`.
    * @param logger - The logger.
    */
   export function addLogger(

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -54,7 +54,7 @@ export class Request extends ServerRequest {
     this.original_request = originalRequest;
     this.url = originalRequest.url;
     this.url_path = this.getUrlPath(originalRequest);
-    this.url_query_params = this.getUrlQueryParams(originalRequest);
+    this.url_query_params = this.getUrlQueryParams();
     if (options) {
       this.response_content_type = options.default_response_content_type ??
         this.response_content_type;
@@ -66,21 +66,24 @@ export class Request extends ServerRequest {
   //////////////////////////////////////////////////////////////////////////////
 
   /**
-     * Used to check which headers are accepted
-     * @param type - It is either a string or an array of strings that contains the Accept Headers
-     * @returns Either true or the string of the correct header
-     */
+   * Used to check which headers are accepted.
+   *
+   * @param type - It is either a string or an array of strings that contains
+   * the Accept Headers.
+   * @returns Either true or the string of the correct header.
+   */
   public accepts(type: string | string[]): boolean | string {
     return new Drash.Services.HttpService().accepts(this, type);
   }
 
   /**
-     * Get a cookie value by the name that is sent in with the request
-     *
-     * @param cookie - The name of the cookie to retrieve
-     *
-     * @return The cookie value associated with the cookie name or undefined if a cookie with that name doesn't exist
-     */
+   * Get a cookie value by the name that is sent in with the request.
+   *
+   * @param cookie - The name of the cookie to retrieve
+   *
+   * @returns The cookie value associated with the cookie name or `undefined` if
+   * a cookie with that name doesn't exist
+   */
   public getCookie(name: string): string {
     const cookies: { [key: string]: string } = getCookies(
       this.original_request,
@@ -89,22 +92,22 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Get the requested file from the body of a multipart/form-data
-     * request, by it's name.
-     *
-     * @param input - The name of the file to get.
-     *
-     * @return The file requested or undefined if not available
-     */
+   * Get the requested file from the body of a multipart/form-data request, by
+   * it's name.
+   *
+   * @param input - The name of the file to get.
+   *
+   * @return The file requested or `undefined` if not available.
+   */
   public getBodyFile(input: string): FormFile | undefined {
     return this.parsed_body.data.file(input);
   }
 
   /**
-     * Get the value of one of this request's body params by its input name.
-     *
-     * @return The corresponding parameter or null if not found
-     */
+   * Get the value of one of this request's body params by its input name.
+   *
+   * @returns The corresponding parameter or null if not found
+   */
   public getBodyParam(input: string): string | null {
     let param;
     if (typeof this.parsed_body.data.value === "function") {
@@ -121,19 +124,19 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Get the value of one of this request's headers by its input name.
-     *
-     * @return The corresponding header or null if not found
-     */
+   * Get the value of one of this request's headers by its input name.
+   *
+   * @returns The corresponding header or null if not found.
+   */
   public getHeaderParam(input: string): string | null {
     return this.headers.get(input);
   }
 
   /**
-     * Get the value of one of this request's path params by its input name.
-     *
-     * @return The corresponding path parameter or null if not found
-     */
+   * Get the value of one of this request's path params by its input name.
+   *
+   * @returns The corresponding path parameter or null if not found.
+   */
   public getPathParam(input: string): string | null {
     // request.path_params is set in Drash.Http.Server.getResourceClass()
     let param = this.path_params[input];
@@ -144,10 +147,10 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Get the value of one of this request's query params by its input name.
-     *
-     * @return The corresponding query parameter from url or null if not found
-     */
+   * Get the value of one of this request's query params by its input name.
+   *
+   * @returns The corresponding query parameter from url or null if not found.
+   */
   public getUrlQueryParam(input: string): string | null {
     const param = this.url_query_params[input];
     if (param) {
@@ -157,10 +160,10 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Get this request's URL path.
-     *
-     * @return Returns the URL path.
-     */
+   * Get this request's URL path.
+   *
+   * @returns The URL path.
+   */
   public getUrlPath(serverRequest: ServerRequest): string {
     let path = serverRequest.url;
 
@@ -182,16 +185,15 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Get the request's URL query params by parsing its URL query string.
-     *
-     * @return Returns the URL query string in key-value pair format.
-     *    ```ts
-     *    {[key: string]: string}
-     *    ```
-     */
-  public getUrlQueryParams(
-    serverRequest: ServerRequest,
-  ): { [key: string]: string } {
+   * Get the request's URL query params by parsing its URL query string.
+   *
+   * @return The URL query string in key-value pair format.
+   *
+   * ```ts
+   * {[key: string]: string}
+   * ```
+   */
+  public getUrlQueryParams(): { [key: string]: string } {
     let queryParams: { [key: string]: string } = {};
 
     try {
@@ -210,10 +212,11 @@ export class Request extends ServerRequest {
   }
 
   /**
-     *Get the specified HTTP request's URL query string.
-     *
-     * @return Returns the URL query string (e.g., key1=value1&key2=value2) without the leading "?" character. Could be null if not available
-     */
+   * Get the specified HTTP request's URL query string.
+   *
+   * @returns The URL query string (e.g., key1=value1&key2=value2) without the
+   * leading "?" character. Could be null if not available
+   */
   public getUrlQueryString(): null | string {
     let queryString = null;
 
@@ -231,10 +234,11 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Does the specified request have a body?
-     *
-     * @return Returns boolean promise. `true` if the request has a body, `false` if not.
-     */
+   * Does the specified request have a body?
+   *
+   * @returns A boolean `Promise`. `true` if the request has a body, `false` if
+   * not.
+   */
   public async hasBody(): Promise<boolean> {
     let contentLength = this.headers.get("content-length");
 
@@ -250,15 +254,13 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Parse the specified request's body.
-     *
-     * @param IOptionsConfig options
-     *
-     * @returns
-     *     Returns the content type of the body, and based on this
-     *     the body itself in that format. If there is no body, it
-     *     returns an empty properties
-     */
+   * Parse the specified request's body.
+   *
+   * @param options - See IOptionsConfig.
+   *
+   * @returns The content type of the body, and based on this the body itself in
+   * that format. If there is no body, it returns an empty properties
+   */
   public async parseBody(
     options?: IOptionsConfig,
   ): Promise<Drash.Interfaces.ParsedRequestBody> {
@@ -360,12 +362,11 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Parse this request's body as application/x-www-form-url-encoded.
-     *
-     * @return
-     *    Returns a Promise of an empty object if no body exists, else a key/value pair
-     *    array e.g. returnValue['someKey']
-     */
+   * Parse this request's body as application/x-www-form-url-encoded.
+   *
+   * @returns A `Promise` of an empty object if no body exists, else a key/value
+   * pair array (e.g., `returnValue['someKey']`).
+   */
   public async parseBodyAsFormUrlEncoded(): Promise<object | Array<unknown>> {
     let body = decoder.decode(
       await Deno.readAll(this.original_request.body),
@@ -378,10 +379,10 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Parse this request's body as application/json.
-     *
-     * @return Returns a promise of a JSON object decoded from request body
-     */
+   * Parse this request's body as application/json.
+   *
+   * @returns A `Promise` of a JSON object decoded from request body.
+   */
   public async parseBodyAsJson(): Promise<object> {
     const data = decoder.decode(
       await Deno.readAll(this.original_request.body),
@@ -390,16 +391,15 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Parse this request's body as multipart/form-data.
-     *
-     * @param body - The request's body.
-     * @param boundary - The boundary of the part (e.g., `----------437192313`)
-     * @param maxMemory - The maximum memory to allocate to this process in megabytes.
-     *
-     * @return Returns a Promise<{ [key: string]: string | FormFile }>
-     *     Returned values can be seen here (look for `readForm`:
-     *     https://deno.land/std@v0.32.0/mime/multipart.ts
-     */
+   * Parse this request's body as multipart/form-data.
+   *
+   * @param body - The request's body.
+   * @param boundary - The boundary of the part (e.g., `----------437192313`)
+   * @param maxMemory - The maximum memory to allocate to this process in
+   * megabytes.
+   *
+   * @return A Promise<{ [key: string]: string | FormFile }>.
+   */
   public async parseBodyAsMultipartFormData(
     body: Reader,
     boundary: string,
@@ -419,11 +419,11 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Respond the the client's request by using the original request's
-     * respond() method.
-     *
-     * @param output - The data to respond with.
-     */
+   * Respond the the client's request by using the original request's
+   * `respond()` method.
+   *
+   * @param output - The data to respond with.
+   */
   public async respond(
     output: Drash.Interfaces.ResponseOutput,
   ): Promise<void> {
@@ -431,11 +431,10 @@ export class Request extends ServerRequest {
   }
 
   /**
-     * Set headers on the request.
-     *
-     * @param headers - Headers in the form of `{[key: string]: string}`
-     * @return void
-     */
+   * Set headers on the request.
+   *
+   * @param headers - Headers in the form of `{[key: string]: string}`.
+   */
   public setHeaders(headers: { [key: string]: string }): void {
     if (headers) {
       for (let key in headers) {

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -101,12 +101,11 @@ export class Response {
   //////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Render html files. Can be used with Drash's template engine or basic
-   * HTML files. This method will read a file based on the `views_path`
-   * and filename passed in. When called, will set the response content
-   * type to "text/html"
+   * Render html files. Can be used with Drash's template engine or basic HTML
+   * files. This method will read a file based on the `views_path` and filename
+   * passed in. When called, will set the response content type to "text/html"
    *
-   * @param args - The arguments used to render
+   * @param args - The arguments used to render.
    *
    * @remarks
    *     // if `views_path` is "/public/views",
@@ -115,7 +114,8 @@ export class Response {
    *     if (!content) throw new Error(...)
    *     this.response.body = content
    *
-   * @return The html content of the view, or false if the `views_path` is not set.
+   * @returns The html content of the view, or false if the `views_path` is not
+   * set.
    */
   public render(
     // deno-lint-ignore no-explicit-any
@@ -144,9 +144,8 @@ export class Response {
   }
 
   /**
-   * Create a cookie to be sent in the response.
-   * Note: Once set, it cannot be read until the next
-   * request
+   * Create a cookie to be sent in the response. Note: Once set, it cannot be
+   * read until the next request
    *
    * @param cookie - Object holding all the properties for a cookie object
    */
@@ -184,7 +183,7 @@ export class Response {
   /**
    * Generate a response.
    *
-   * @return The response in string form
+   * @returns The response in string form.
    */
   public generateResponse(): string {
     let contentType = this.headers.get("Content-Type");
@@ -217,10 +216,9 @@ export class Response {
   /**
    * Get the status message based on the status code.
    *
-   * @return
-   *     Returns the status message associated with this.status_code. For
-   *     example, if the response's status_code is 200, then this method
-   *     will return "OK" as the status message.
+   * @return The status message associated with this.status_code. For example,
+   * if the response's status_code is 200, then this method will return "OK" as
+   * the status message.
    */
   public getStatusMessage(): null | string {
     let message = STATUS_TEXT.get(this.status_code);
@@ -231,10 +229,10 @@ export class Response {
    * Get the full status message based on the status code. This is just the
    * status code and the status message together. For example:
    *
-   *     If the status code is 200, then this will return "200 (OK)"
-   *     If the status code is 404, then this will return "404 (Not Found)"
+   * - If the status code is 200, then this will return "200 (OK)"
+   * - If the status code is 404, then this will return "404 (Not Found)"
    *
-   * @return The status code
+   * @returns The status code
    */
   public getStatusMessageFull(): null | string {
     let message = STATUS_TEXT.get(this.status_code);
@@ -244,11 +242,10 @@ export class Response {
   /**
    * Send the response to the client making the request.
    *
-   * @return
-   *     Returns a Promise of the output which is passed to `request.respond()`. The output
-   *     is only returned for unit testing purposes. It is not intended to be
-   *     used elsewhere as this call is the last call in the
-   *     request-resource-response lifecycle.
+   * @returns A `Promise` of the output which is passed to `request.respond()`.
+   * The output is only returned for unit testing purposes. It is not intended
+   * to be used elsewhere as this call is the last call in the
+   * request-resource-response lifecycle.
    */
   public async send(): Promise<Drash.Interfaces.ResponseOutput> {
     let body = await this.generateResponse();
@@ -265,13 +262,13 @@ export class Response {
   }
 
   /**
-   * Send the response of a static asset (e.g., a CSS file, JS file, PDF
-   * file, etc.) to the client making the request.
+   * Send the response of a static asset (e.g., a CSS file, JS file, PDF file,
+   * etc.) to the client making the request.
    *
    * @param file - The file that will be served to the client.
-   * @param contents - The content in a Uint8Array
+   * @param contents - The content in a `Uint8Array`.
    *
-   * @return The final output to be sent
+   * @returns The final output to be sent.
    */
   public sendStatic(
     file: null | string,
@@ -294,16 +291,15 @@ export class Response {
   //////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Get the content type from the request object's "Accept" header. Default
-   * to the response_output config passed in when the server was created if
-   * no accept header is specified. If no response_output config was passed
-   * in during server creation, then default to application/json.
+   * Get the content type from the request object's "Accept" header. Default to
+   * the response_output config passed in when the server was created if no
+   * accept header is specified. If no response_output config was passed in
+   * during server creation, then default to application/json.
    *
    *
-   * @return
-   *     Returns a content type to set as this object's content-type header. If
-   *     multiple content types are passed in, then return the first accepted
-   *     content type.
+   * @returns A content type to set as this object's content-type header. If
+   * multiple content types are passed in, then return the first accepted
+   * content type.
    */
   protected getContentTypeFromRequestAcceptHeader(): string {
     const accept = this.request.headers.get("Accept") ||
@@ -338,12 +334,12 @@ export class Response {
    * Redirect the client to another URL.
    *
    * @param httpStatusCode - Response's status code.
-   *     Permanent: (301 and 308)
-   *     Temporary: (302, 303, and 307)
+   * - Permanent: (301 and 308)
+   * - Temporary: (302, 303, and 307)
+   * @param location - URL of desired redirection. Relative or external paths
+   * (e.g., "/users/1", https://drash.land)
    *
-   * @param location - URL of desired redirection. Relative or external paths (e.g., "/users/1", https://drash.land)
-   *
-   * @return The final output to be sent
+   * @returns The final output to be sent.
    */
   public redirect(
     httpStatusCode: number,

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -216,7 +216,7 @@ export class Response {
   /**
    * Get the status message based on the status code.
    *
-   * @return The status message associated with this.status_code. For example,
+   * @returns The status message associated with this.status_code. For example,
    * if the response's status_code is 200, then this method will return "OK" as
    * the status message.
    */

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -147,10 +147,9 @@ export class Server {
    *
    * @param request - The request object.
    *
-   * @return
-   *     Returns a Drash request object--hydrated with more properties and
-   *     methods than the ServerRequest object. These properties and methods are
-   *     used throughout the Drash request-resource-response lifecycle.
+   * @returns Returns a Drash request object--hydrated with more properties and
+   * methods than the ServerRequest object. These properties and methods are
+   * used throughout the Drash request-resource-response lifecycle.
    */
   public async getRequest(
     serverRequest: ServerRequest,
@@ -176,7 +175,7 @@ export class Server {
    *
    * @param request - The request object.
    *
-   * @return Returns a Promise of ResponseOutput
+   * @returns A Promise of ResponseOutput.
    */
   public async handleHttpRequest(
     serverRequest: Drash.Http.Request,
@@ -284,7 +283,7 @@ export class Server {
    * @param resource - (optional) Pass in the resource that threw the error.
    * @param response - (optional) Pass in the response that threw the error.
    *
-   * @return Returns a Promise of ResponseOutput
+   * @returns A Promise of ResponseOutput.
    */
   public async handleHttpRequestError(
     request: Drash.Http.Request,
@@ -355,9 +354,8 @@ export class Server {
    *
    * @param request - The request object
    *
-   * @return
-   *     Returns the response as stringified JSON. This is only used for unit
-   *     testing purposes.
+   * @returns The response as stringified JSON. This is only used for
+   * unit testing purposes.
    */
   public handleHttpRequestForFavicon(
     request: Drash.Http.Request,
@@ -404,9 +402,8 @@ export class Server {
    *
    * @param request - The request object
    *
-   * @return
-   *     Returns the response as stringified JSON. This is only used for unit
-   *     testing purposes.
+   * @returns The response as stringified JSON. This is only used for unit
+   * testing purposes.
    */
   public async handleHttpRequestForStaticPathAsset(
     request: Drash.Http.Request,
@@ -451,7 +448,7 @@ export class Server {
    *
    * @param options - The HTTPOptions interface from https://deno.land/std/http/server.ts.
    *
-   * @return Returns a Promise of the Deno server from the serve() call.
+   * @returns A Promise of the Deno server from the serve() call.
    */
   public async run(options: HTTPOptions): Promise<DenoServer> {
     if (!options.hostname) {
@@ -486,7 +483,7 @@ export class Server {
    *
    * @param options - The HTTPSOptions interface from https://deno.land/std/http/server.ts.
    *
-   * @return Returns a Promise of the Deno server from the serve() call.
+   * @returns A Promise of the Deno server from the serve() call.
    */
   public async runTLS(options: HTTPSOptions): Promise<DenoServer> {
     if (!options.hostname) {
@@ -656,7 +653,7 @@ export class Server {
    * @param code - The code that should be used
    * @param message - The message it should be displayed
    *
-   * @return A new http exception
+   * @returns A new http exception.
    */
   protected httpErrorResponse(
     code: number,
@@ -670,11 +667,9 @@ export class Server {
    *
    * @param request - The request object.
    *
-   * @return
-   *     Returns a `Drash.Http.Resource` object if the URL path of the request
-   *     can be matched to a `Drash.Http.Resource` object's paths.
-   *
-   *     Returns `undefined` if a `Drash.Http.Resource` object can't be matched.
+   * @returns A `Drash.Http.Resource` object if the URL path of the request can
+   * be matched to a `Drash.Http.Resource` object's paths. Otherwise, it returns
+   * `undefined` if a `Drash.Http.Resource` object can't be matched.
    */
   protected getResourceClass(
     request: Drash.Http.Request,
@@ -712,8 +707,8 @@ export class Server {
    *
    * @param request - The request object
    *
-   * @return
-   *     Returns true if the request targets a static path.
+   * @returns Either true or false. If the request targets a static path then it
+   * returns true. Otherwise it returns false.
    */
   protected requestTargetsStaticPath(serverRequest: ServerRequest): boolean {
     if (this.static_paths.length <= 0) {

--- a/src/services/http_service.ts
+++ b/src/services/http_service.ts
@@ -10,27 +10,30 @@ export class HttpService {
   //////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Checks if the incoming request accepts the type(s) in the parameter.
-   * This method will check if the requests `Accept` header contains
-   * the passed in types
+   * Checks if the incoming request accepts the type(s) in the parameter.  This
+   * method will check if the requests `Accept` header contains the passed in
+   * types
    *
-   * @param request - The request object containing the Accept header.
-   * @param type - The content-type/mime-type(s) to check if the request accepts it
+   * @param request - The request object containing the `Accept` header.
+   * @param type - The content-type/mime-type(s) to check if the request accepts
+   * it.
    *
    * @remarks
    * Below are examples of how this method is called from the request object
    * and used in resources:
    *
    * ```ts
-   * // YourResource.ts - assume the request accepts "text/html"
-   * const isAccepted = this.request.accepts("text/html"); // "text/html"
+   * // File: your_resource.ts // assumes the request accepts "text/html"
+   * const val = this.request.accepts("text/html"); // "text/html"
+   *
    * // or can also pass in an array and will match on the first one found
-   * const isAccepted = this.request.accepts(["text/html", "text/xml"]); // "text/html"
+   * const val = this.request.accepts(["text/html", "text/xml"]); // "text/html"
+   *
    * // and will return false if not found
-   * const isAccepted = this.request.accepts("text/xml"); // false
+   * const val = this.request.accepts("text/xml"); // false
    * ```
-   * @return False if the request doesn't accept any of the passed in types,
-   *     or the content type that was matches
+   * @returns False if the request doesn't accept any of the passed in types, or
+   * the content type that was matches
    */
   public accepts(
     request: Drash.Http.Request,
@@ -60,13 +63,13 @@ export class HttpService {
    * Get a MIME type for a file based on its extension.
    *
    * @param filePath - The file path in question.
-   * @param fileIsUrl - (optional) Is the file path  a URL to a file? Defaults to false.
-   *     If the file path is a URL, then this method will make sure the URL
-   *     query string is not included while doing a lookup of the file's
-   *     extension.
+   * @param fileIsUrl - (optional) Is the file path  a URL to a file? Defaults
+   * to false.  If the file path is a URL, then this method will make sure the
+   * URL query string is not included while doing a lookup of the file's
+   * extension.
    *
-   * @return Returns the name of the MIME type based on the extension of the
-   *     file path .
+   * @returns The name of the MIME type based on the extension of the file path
+   * .
    */
   public getMimeType(
     filePath: string | undefined,

--- a/src/services/string_service.ts
+++ b/src/services/string_service.ts
@@ -6,27 +6,26 @@ export class StringService {
   /**
    * Parse a URL query string in it's raw form.
    *
-   * If the request body's content type is application/json, then
+   * If the request body's content type is `application/json`, then:
    * {"username":"root","password":"alpine"} becomes
    * { username: "root", password: "alpine" }.
    *
-   * If the request body's content type is
-   * application/x-www-form-urlencoded, then username=root&password=alpine
-   * becomes { username: "root", password: "alpine" }.
+   * If the request body's content type is `application/x-www-form-urlencoded`,
+   * then:
+   * `username=root&password=alpine` becomes
+   * `{ username: "root", password: "alpine" }`.
    *
-   * @param queryParamsString - The query params string (e.g., hello=world&ok=then&git=hub)
-   * @param keyFormat - (optional) The format the keys should be mutated to. For example, if
-   *     "underscore" is specified, then the keys will be converted from
-   *     key-name to key_name. Defaults to "normal", which does not mutate the
-   *     keys.
-   * @param keyCase - (optional) The case the keys should be mutated to. For example, if
-   *     "lowercase" is specified, then the keys will be converted from Key-Name
-   *     to key-name. Defaults to "normal", which does not mutate the keys.
+   * @param queryParamsString - The query params string (e.g.,
+   * hello=world&ok=then&git=hub)
+   * @param keyFormat - (optional) The format the keys should be mutated to. For
+   * example, if "underscore" is specified, then the keys will be converted from
+   * key-name to key_name. Defaults to "normal", which does not mutate the keys.
+   * @param keyCase - (optional) The case the keys should be mutated to. For
+   * example, if "lowercase" is specified, then the keys will be converted from
+   * Key-Name to key-name. Defaults to "normal", which does not mutate the keys.
    *
-   * @return 
-   *     Returns a key-value pair array.
-   *     `{ [key: string]: string }`
-   *     Returns an empty object if the first argument is empty.
+   * @returns A key-value pair array.  `{ [key: string]: string }`. Returns an
+   * empty object if the first argument is empty.
    */
   static parseQueryParamsString(
     queryParamsString: string,

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -453,7 +453,7 @@ function getUrlQueryParamsTests() {
   Rhum.testCase("Returns {} with no query strings", async () => {
     const serverRequest = members.mockRequest("/");
     const request = new Drash.Http.Request(serverRequest);
-    const queryParams = request.getUrlQueryParams(request);
+    const queryParams = request.getUrlQueryParams();
     Rhum.asserts.assertEquals(queryParams, {});
   });
 
@@ -464,7 +464,7 @@ function getUrlQueryParamsTests() {
         "/api/v2/users?name=John&age=44",
       );
       const request = new Drash.Http.Request(serverRequest);
-      const queryParams = request.getUrlQueryParams(request);
+      const queryParams = request.getUrlQueryParams();
       Rhum.asserts.assertEquals(queryParams, {
         name: "John",
         age: "44",


### PR DESCRIPTION
No issue for this. I was converting Sockets to use TSDoc and decided to check Drash's doc block formatting and the `@return` vs `@returns` annotations.