### PR TITLE
Issue #324 execute middleware for static assets

### DIFF
--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -270,14 +270,11 @@ export class Response {
    *
    * @returns The final output to be sent.
    */
-  public sendStatic(
-    file: null | string,
-    contents: Uint8Array | string = "",
-  ): Drash.Interfaces.ResponseOutput {
+  public sendStatic(): Drash.Interfaces.ResponseOutput {
     let output: Drash.Interfaces.ResponseOutput = {
       status: this.status_code,
       headers: this.headers,
-      body: file ? Deno.readFileSync(file) : contents,
+      body: this.body as Uint8Array
     };
 
     this.request.respond(output);

--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -274,7 +274,7 @@ export class Response {
     let output: Drash.Interfaces.ResponseOutput = {
       status: this.status_code,
       headers: this.headers,
-      body: this.body as Uint8Array
+      body: this.body as Uint8Array,
     };
 
     this.request.respond(output);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -182,14 +182,7 @@ export class Server {
   ): Promise<Drash.Interfaces.ResponseOutput> {
     // Handle a request to a static path
     if (this.requestTargetsStaticPath(serverRequest)) {
-      try {
-        return await this.handleHttpRequestForStaticPathAsset(serverRequest);
-      } catch (error) {
-        return await this.handleHttpRequestError(
-          serverRequest as Drash.Http.Request,
-          this.httpErrorResponse(400, error.message),
-        );
-      }
+      return await this.handleHttpRequestForStaticPathAsset(serverRequest);
     }
 
     // Handle a request to the favicon

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -426,8 +426,8 @@ export class Server {
       const extension = request.url.split(".")[1];
 
       if (
-        this.configs.pretty_links == null
-        || extension != null
+        this.configs.pretty_links == null ||
+        extension != null
       ) {
         response.body = Deno.readFileSync(`${this.directory}/${request.url}`);
         await this.executeMiddlewareServerLevelAfterRequest(request, response);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -444,7 +444,7 @@ export class Server {
     } catch (error) {
       return await this.handleHttpRequestError(
         request,
-        this.httpErrorResponse(404),
+        this.httpErrorResponse(error.code ?? 404, error.message),
       );
     }
   }

--- a/tests/unit/http/middleware_test.ts
+++ b/tests/unit/http/middleware_test.ts
@@ -138,6 +138,36 @@ Rhum.testPlan("http/middleware_test.ts", () => {
       const response = await server.handleHttpRequest(request);
       members.assertResponseJsonEquals(members.responseBody(response), "got");
     });
+
+    Rhum.testCase("before_request: static path asset", async () => {
+      let server = new Drash.Http.Server({
+        static_paths: ["/assets"],
+        middleware: {
+          before_request: [BeforeRequestStaticPathAsset],
+        },
+      });
+      const request = members.mockRequest("/assets/test.js", "get");
+      const response = await server.handleHttpRequest(request);
+      members.assertResponseJsonEquals(
+        members.responseBody(response),
+        "Hello, I'm a static path asset before request middleware.",
+      );
+    });
+
+    Rhum.testCase("after_request: static path asset", async () => {
+      let server = new Drash.Http.Server({
+        static_paths: ["/assets"],
+        middleware: {
+          after_request: [AfterRequestStaticPathAsset],
+        },
+      });
+      const request = members.mockRequest("/assets/test.js", "get");
+      const response = await server.handleHttpRequest(request);
+      members.assertResponseJsonEquals(
+        members.responseBody(response),
+        "this static path asset's contents got changed",
+      );
+    });
   });
 });
 
@@ -216,5 +246,21 @@ function VerifyCsrfToken(req: Drash.Http.Request) {
       400,
       "Wrong CSRF token, dude.",
     );
+  }
+}
+
+function BeforeRequestStaticPathAsset(req: Drash.Http.Request) {
+  throw new Drash.Exceptions.HttpException(
+    418,
+    "Hello, I'm a static path asset before request middleware.",
+  );
+}
+
+function AfterRequestStaticPathAsset(
+  req: Drash.Http.Request,
+  res?: Drash.Http.Response,
+) {
+  if (res) {
+    res.body = "this static path asset's contents got changed";
   }
 }

--- a/tests/unit/http/response_test.ts
+++ b/tests/unit/http/response_test.ts
@@ -321,7 +321,8 @@ Rhum.testPlan("http/response_test.ts", () => {
     Rhum.testCase("Returns the contents if a file is passed in", async () => {
       const request = members.mockRequest("/");
       const response = new Drash.Http.Response(request);
-      const actual = response.sendStatic("./tests/data/static_file.txt");
+      repsonse.body = Deno.readFileSync("./tests/data/static_file.txt");
+      const actual = response.sendStatic();
       const headers = new Headers();
       headers.set("content-type", "undefined");
       const expected = {

--- a/tests/unit/http/response_test.ts
+++ b/tests/unit/http/response_test.ts
@@ -321,7 +321,7 @@ Rhum.testPlan("http/response_test.ts", () => {
     Rhum.testCase("Returns the contents if a file is passed in", async () => {
       const request = members.mockRequest("/");
       const response = new Drash.Http.Response(request);
-      repsonse.body = Deno.readFileSync("./tests/data/static_file.txt");
+      response.body = Deno.readFileSync("./tests/data/static_file.txt");
       const actual = response.sendStatic();
       const headers = new Headers();
       headers.set("content-type", "undefined");


### PR DESCRIPTION
Closes #324 

**Description**

* This PR removes logic that makes `response.sendStatic()` read files. The caller is now in charge of reading files, setting `response.body` and then calling `sendStatic()`. `sendStatic()` takes 0 arguments now.
* This PR allows middleware to execute before and after HTTP requests to static assets