### PR TITLE
create app script fetching

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -50,6 +50,7 @@ jobs:
           # for the create_app script will fetch the latest version of Drash
           # and not the new branch in the new PR--testing against old code.
           export CURRENT_BRANCH=$(git branch --show-current)
+          echo $(git branch --show-current)
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,9 +51,7 @@ jobs:
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          $CURRENT_BRANCH=$GITHUB_HEAD_REF
-          echo $GITHUB_HEAD_REF
-          deno cache "https://deno.land/x/drash@$(git branch --show-current)/create_app.ts"
+          deno cache "https://deno.land/x/drash@$GITHUB_HEAD_REF/create_app.ts"
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,17 +41,19 @@ jobs:
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      - name: Create App (http)
-        if: startsWith(matrix.config.os, 'windows')
-          run: |
-            $Env:CURRENT_BRANCH = ${GITHUB_HEAD_REF#refs/heads/}
-            deno cache https://deno.land/x/drash@$Env:CURRENT_BRANCH/create_app.ts
-            deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
-        if: !startsWith(matrix.config.os, 'windows')
-          run: |
-            export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
-            deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
-            deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+      - name: Create App (http: windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          $Env:CURRENT_BRANCH = ${GITHUB_HEAD_REF#refs/heads/}
+          deno cache https://deno.land/x/drash@$Env:CURRENT_BRANCH/create_app.ts
+          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+
+      - name: Create App (http: nix)
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os 'macos')
+        run: |
+          export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
+          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:
     # Only one OS is required since fmt is cross platform

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -52,6 +52,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: |
           $CURRENT_BRANCH=$GITHUB_HEAD_REF
+          echo $GITHUB_HEAD_REF
           deno cache "https://deno.land/x/drash@$(git branch --show-current)/create_app.ts"
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
-          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
       - name: Create APP (http)
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          set CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+          $CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        env:
+          CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
 
       - name: Install Deno v${{ matrix.deno }}
         uses: denolib/setup-deno@master
@@ -41,17 +43,8 @@ jobs:
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      - name: Create App (http windows)
-        if: startsWith(matrix.os, 'windows')
+      - name: Create App (http)
         run: |
-          $CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
-          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
-          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
-
-      - name: Create App (http nix)
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        run: |
-          export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,8 +43,7 @@ jobs:
 
       - name: Create APP (http)
         run: |
-          export CURRENT_BRANCH=$(git branch --show-current)
-          echo $(git branch --show-current)
+          export CURRENT_BRANCH=${GITHUB_REF##*/}
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Create APP (http)
         run: |
+          deno cache create_app.ts
           export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          $Env:CURRENT_BRANCH = ${GITHUB_HEAD_REF#refs/heads/}
-          deno cache https://deno.land/x/drash@$Env:CURRENT_BRANCH/create_app.ts
+          $env:CURRENT_BRANCH = ${GITHUB_HEAD_REF#refs/heads/}
+          deno cache https://deno.land/x/drash@$env:CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
       - name: Create App (http nix)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,29 +24,29 @@ jobs:
         with:
           deno-version: ${{ matrix.deno }}
 
-      - name: Unit
-        run: deno test tests/unit/tests.ts --config tsconfig.json --allow-net --allow-write --allow-read --allow-env
+      # - name: Unit
+      #   run: deno test tests/unit/tests.ts --config tsconfig.json --allow-net --allow-write --allow-read --allow-env
 
-      - name: Integration
-        run: |
-          deno test --allow-all --config tsconfig.json tests/integration/app_3000_resources/tests.ts
-          deno test --allow-all --config tsconfig.json tests/integration/app_3001_views/tests.ts
-          # deno test --allow-all --config tsconfig.json tests/integration/app_3002_https/tests.ts
-          deno test --allow-all --config tsconfig.json tests/integration/app_3003_middleware/tests.ts
-          deno test --allow-all --config tsconfig.json tests/integration/app_3004_pretty_links/tests.ts
-          deno test --allow-all --config tsconfig.json tests/integration/app_3005_middleware_resource_level/tests.ts
+      # - name: Integration
+      #   run: |
+      #     deno test --allow-all --config tsconfig.json tests/integration/app_3000_resources/tests.ts
+      #     deno test --allow-all --config tsconfig.json tests/integration/app_3001_views/tests.ts
+      #     # deno test --allow-all --config tsconfig.json tests/integration/app_3002_https/tests.ts
+      #     deno test --allow-all --config tsconfig.json tests/integration/app_3003_middleware/tests.ts
+      #     deno test --allow-all --config tsconfig.json tests/integration/app_3004_pretty_links/tests.ts
+      #     deno test --allow-all --config tsconfig.json tests/integration/app_3005_middleware_resource_level/tests.ts
 
-      - name: Create App (local)
-        run: |
-          deno cache create_app.ts
-          deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
+      # - name: Create App (local)
+      #   run: |
+      #     deno cache create_app.ts
+      #     deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      - name: Create App (http nix)
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        run: |
-          export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
-          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
-          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+      # - name: Create App (http nix)
+      #   if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+      #   run: |
+      #     export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+      #     deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
+      #     deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        env:
-          CURRENT_BRANCH: ${GITHUB_HEAD_REF#refs/heads/}
 
       - name: Install Deno v${{ matrix.deno }}
         uses: denolib/setup-deno@master
@@ -44,6 +42,8 @@ jobs:
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
       - name: Create App (http)
+        env:
+          CURRENT_BRANCH: ${GITHUB_HEAD_REF#refs/heads/}
         run: |
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create APP (http)
         run: |
-          export CURRENT_BRANCH=${GITHUB_REF##*/}
+          export CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,15 +41,15 @@ jobs:
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      - name: Create App (http: windows)
+      - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
           $Env:CURRENT_BRANCH = ${GITHUB_HEAD_REF#refs/heads/}
           deno cache https://deno.land/x/drash@$Env:CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
-      - name: Create App (http: nix)
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os 'macos')
+      - name: Create App (http nix)
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: |
           export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,17 +41,17 @@ jobs:
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      - name: Create App (http windows)
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          $CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
-          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
-          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
-
       - name: Create App (http nix)
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: |
           export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
+          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+
+      - name: Create App (http windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          $CURRENT_BRANCH=$(git branch --show-current)
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,6 +43,12 @@ jobs:
 
       - name: Create APP (http)
         run: |
+          # These tests will almost always fail when in a new branch in a new
+          # PR. They will pass when merged in though because say we make a fix
+          # to the create_app script, the fix will be in a new branch in a new
+          # PR and not yet merged into the latest version of Drash. The tests
+          # for the create_app script will fetch the latest version of Drash
+          # and not the new branch in the new PR--testing against old code.
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          $env:CURRENT_BRANCH = ${GITHUB_HEAD_REF#refs/heads/}
-          deno cache https://deno.land/x/drash@$env:CURRENT_BRANCH/create_app.ts
+          set CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
       - name: Create App (http nix)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Create APP
         run: |
           deno cache create_app.ts
-          deno test tests/cli/create_app_test.ts --allow-read --allow-write --allow-run --allow-env
+          deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
+          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:
     # Only one OS is required since fmt is cross platform

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,16 +36,22 @@ jobs:
           deno test --allow-all --config tsconfig.json tests/integration/app_3004_pretty_links/tests.ts
           deno test --allow-all --config tsconfig.json tests/integration/app_3005_middleware_resource_level/tests.ts
 
-      - name: Create APP (local)
+      - name: Create App (local)
         run: |
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      - name: Create APP (http)
-        run: |
-          export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
-          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
-          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+      - name: Create App (http)
+        if: startsWith(matrix.config.os, 'windows')
+          run: |
+            $Env:CURRENT_BRANCH = ${GITHUB_HEAD_REF#refs/heads/}
+            deno cache https://deno.land/x/drash@$Env:CURRENT_BRANCH/create_app.ts
+            deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+        if: !startsWith(matrix.config.os, 'windows')
+          run: |
+            export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+            deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
+            deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:
     # Only one OS is required since fmt is cross platform

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create APP (http)
         run: |
-          export CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
+          export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        env:
+        env: |
           CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
 
       - name: Install Deno v${{ matrix.deno }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,10 +36,14 @@ jobs:
           deno test --allow-all --config tsconfig.json tests/integration/app_3004_pretty_links/tests.ts
           deno test --allow-all --config tsconfig.json tests/integration/app_3005_middleware_resource_level/tests.ts
 
-      - name: Create APP
+      - name: Create APP (local)
         run: |
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
+          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+
+      - name: Create APP (http)
+        run: |
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,34 +24,33 @@ jobs:
         with:
           deno-version: ${{ matrix.deno }}
 
-      # - name: Unit
-      #   run: deno test tests/unit/tests.ts --config tsconfig.json --allow-net --allow-write --allow-read --allow-env
+      - name: Unit
+        run: deno test tests/unit/tests.ts --config tsconfig.json --allow-net --allow-write --allow-read --allow-env
 
-      # - name: Integration
-      #   run: |
-      #     deno test --allow-all --config tsconfig.json tests/integration/app_3000_resources/tests.ts
-      #     deno test --allow-all --config tsconfig.json tests/integration/app_3001_views/tests.ts
-      #     # deno test --allow-all --config tsconfig.json tests/integration/app_3002_https/tests.ts
-      #     deno test --allow-all --config tsconfig.json tests/integration/app_3003_middleware/tests.ts
-      #     deno test --allow-all --config tsconfig.json tests/integration/app_3004_pretty_links/tests.ts
-      #     deno test --allow-all --config tsconfig.json tests/integration/app_3005_middleware_resource_level/tests.ts
+      - name: Integration
+        run: |
+          deno test --allow-all --config tsconfig.json tests/integration/app_3000_resources/tests.ts
+          deno test --allow-all --config tsconfig.json tests/integration/app_3001_views/tests.ts
+          # deno test --allow-all --config tsconfig.json tests/integration/app_3002_https/tests.ts
+          deno test --allow-all --config tsconfig.json tests/integration/app_3003_middleware/tests.ts
+          deno test --allow-all --config tsconfig.json tests/integration/app_3004_pretty_links/tests.ts
+          deno test --allow-all --config tsconfig.json tests/integration/app_3005_middleware_resource_level/tests.ts
 
-      # - name: Create App (local)
-      #   run: |
-      #     deno cache create_app.ts
-      #     deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
+      - name: Create App (local)
+        run: |
+          deno cache create_app.ts
+          deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      # - name: Create App (http nix)
-      #   if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-      #   run: |
-      #     export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
-      #     deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
-      #     deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+      - name: Create App (http nix)
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        run: |
+          export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
+          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          deno cache "https://deno.land/x/drash@$GITHUB_HEAD_REF/create_app.ts"
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Create APP (http)
         run: |
-          deno cache create_app.ts
           export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,10 +41,17 @@ jobs:
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      - name: Create App (http)
-        env:
-          CURRENT_BRANCH: ${GITHUB_HEAD_REF#refs/heads/}
+      - name: Create App (http windows)
+        if: startsWith(matrix.os, 'windows')
         run: |
+          set $CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
+          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+
+      - name: Create App (http nix)
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        run: |
+          export CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          $CURRENT_BRANCH=$(git branch --show-current)
+          $CURRENT_BRANCH="test"
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,8 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        env: |
-          CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+        env:
+          CURRENT_BRANCH: ${GITHUB_HEAD_REF#refs/heads/}
 
       - name: Install Deno v${{ matrix.deno }}
         uses: denolib/setup-deno@master

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,12 +43,6 @@ jobs:
 
       - name: Create APP (http)
         run: |
-          # These tests will almost always fail when in a new branch in a new
-          # PR. They will pass when merged in though because say we make a fix
-          # to the create_app script, the fix will be in a new branch in a new
-          # PR and not yet merged into the latest version of Drash. The tests
-          # for the create_app script will fetch the latest version of Drash
-          # and not the new branch in the new PR--testing against old code.
           export CURRENT_BRANCH=$(git branch --show-current)
           echo $(git branch --show-current)
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          $CURRENT_BRANCH=$($GITHUB_HEAD_REF -replace refs/heads/)
-          deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
+          $CURRENT_BRANCH=$GITHUB_HEAD_REF
+          deno cache "https://deno.land/x/drash@$(git branch --show-current)/create_app.ts"
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          $CURRENT_BRANCH="test"
+          $CURRENT_BRANCH=$($GITHUB_HEAD_REF -replace refs/heads/)
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Create App (http windows)
         if: startsWith(matrix.os, 'windows')
         run: |
-          set $CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
+          $CURRENT_BRANCH=${GITHUB_HEAD_REF#refs/heads/}
           deno cache https://deno.land/x/drash@$CURRENT_BRANCH/create_app.ts
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,6 +49,7 @@ jobs:
           # PR and not yet merged into the latest version of Drash. The tests
           # for the create_app script will fetch the latest version of Drash
           # and not the new branch in the new PR--testing against old code.
+          export CURRENT_BRANCH=$(git branch --show-current)
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:

--- a/create_app.ts
+++ b/create_app.ts
@@ -26,12 +26,14 @@ async function copyFile(filePath: string, outputFile: string): Promise<void> {
   const fullFilePath = Deno.build.os === "windows"
     ? `${drashDir}/console/create_app${filePath}`.replace(/\//g, "\\")
     : `${drashDir}/console/create_app${filePath}`;
+    console.log(fullFilePath);
   outputFile = Deno.build.os === "windows"
     ? outputFile.replace(/\//g, "\\")
     : outputFile;
   console.info(`Copy ${fullFilePath} contents to:`);
   console.info(`  ${cwd}${outputFile}`);
-  console.log(fullFilePath);
+  console.log("test");
+  console.log(cwd + outputFile);
   const contents = Deno.readFileSync(fullFilePath);
   Deno.writeFileSync(cwd + outputFile, contents);
 }

--- a/create_app.ts
+++ b/create_app.ts
@@ -31,10 +31,14 @@ async function copyFile(filePath: string, outputFile: string): Promise<void> {
     : outputFile;
   console.info(`Copy ${fullFilePath} contents to:`);
   console.info(`  ${cwd}${outputFile}`);
-  console.log(import.meta.url);
   try {
-    const response = await fetch(fullFilePath);
-    const contents = encoder.encode(await response.text());
+    let contents;
+    if (import.meta.url.includes("http")) {
+      const response = await fetch(fullFilePath);
+      contents = encoder.encode(await response.text());
+    } else {
+      contents = Deno.readFileSync(fullFilePath);
+    }
     Deno.writeFileSync(cwd + outputFile, contents);
   } catch (error) {
     console.error(error);

--- a/create_app.ts
+++ b/create_app.ts
@@ -34,7 +34,6 @@ async function copyFile(filePath: string, outputFile: string): Promise<void> {
   try {
     const response = await fetch(fullFilePath);
     const contents = encoder.encode(await response.text());
-    console.log(contents);
     Deno.writeFileSync(cwd + outputFile, contents);
   } catch (error) {
     console.error(error);

--- a/create_app.ts
+++ b/create_app.ts
@@ -31,6 +31,7 @@ async function copyFile(filePath: string, outputFile: string): Promise<void> {
     : outputFile;
   console.info(`Copy ${fullFilePath} contents to:`);
   console.info(`  ${cwd}${outputFile}`);
+  console.log(import.meta.url);
   try {
     const response = await fetch(fullFilePath);
     const contents = encoder.encode(await response.text());

--- a/create_app.ts
+++ b/create_app.ts
@@ -34,7 +34,8 @@ async function copyFile(filePath: string, outputFile: string): Promise<void> {
   console.info(`  ${cwd}${outputFile}`);
   console.log("test");
   console.log(cwd + outputFile);
-  const contents = Deno.readFileSync(fullFilePath);
+  const response = await fetch(fullFilePath);
+  const contents = encoder.encode(await response.text());
   Deno.writeFileSync(cwd + outputFile, contents);
 }
 

--- a/create_app.ts
+++ b/create_app.ts
@@ -36,6 +36,7 @@ async function copyFile(filePath: string, outputFile: string): Promise<void> {
   console.log(cwd + outputFile);
   const response = await fetch(fullFilePath);
   const contents = encoder.encode(await response.text());
+  console.log(contents);
   Deno.writeFileSync(cwd + outputFile, contents);
 }
 

--- a/create_app.ts
+++ b/create_app.ts
@@ -34,10 +34,14 @@ async function copyFile(filePath: string, outputFile: string): Promise<void> {
   console.info(`  ${cwd}${outputFile}`);
   console.log("test");
   console.log(cwd + outputFile);
-  const response = await fetch(fullFilePath);
-  const contents = encoder.encode(await response.text());
-  console.log(contents);
-  Deno.writeFileSync(cwd + outputFile, contents);
+  try {
+    const response = await fetch(fullFilePath);
+    const contents = encoder.encode(await response.text());
+    console.log(contents);
+    Deno.writeFileSync(cwd + outputFile, contents);
+  } catch (error) {
+    console.error(error);
+  }
 }
 
 /**

--- a/create_app.ts
+++ b/create_app.ts
@@ -26,14 +26,11 @@ async function copyFile(filePath: string, outputFile: string): Promise<void> {
   const fullFilePath = Deno.build.os === "windows"
     ? `${drashDir}/console/create_app${filePath}`.replace(/\//g, "\\")
     : `${drashDir}/console/create_app${filePath}`;
-    console.log(fullFilePath);
   outputFile = Deno.build.os === "windows"
     ? outputFile.replace(/\//g, "\\")
     : outputFile;
   console.info(`Copy ${fullFilePath} contents to:`);
   console.info(`  ${cwd}${outputFile}`);
-  console.log("test");
-  console.log(cwd + outputFile);
   try {
     const response = await fetch(fullFilePath);
     const contents = encoder.encode(await response.text());

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -37,8 +37,9 @@ function getOsTmpDirName() {
  * @param string filename eg originCWD + "/console/create_app/app.ts" or tmpDir + "/app.ts"
  */
 function getFileContent(filePathAndName: string): string {
+  const fullFilepath = originalCWD + filePathAndName;
   const fileContent = decoder.decode(
-    Deno.readFileSync(originalCWD + filePathAndName),
+    Deno.readFileSync(fullFilepath),
   ).replace(/\r\n/g, "\n");
   return fileContent;
 }
@@ -94,14 +95,9 @@ Rhum.testPlan("create_app_test.ts", () => {
       const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
       Rhum.asserts.assertEquals(
         stderr,
-        "Download https://deno.land/x/drash@" + latestBranch +
-          "/create_app.ts\n" +
-          "Download https://deno.land/x/drash@" + latestBranch + "/deps.ts\n" +
-          "Check https://deno.land/x/drash@" + latestBranch +
-          "/create_app.ts\n" +
-          red(
-            "Too few options were given. Use the --help option for more information.",
-          ) + "\n",
+        red(
+          "Too few options were given. Use the --help option for more information.",
+        ) + "\n",
       );
       Rhum.asserts.assertEquals(stdout, "");
       Rhum.asserts.assertEquals(status.code, 1);

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -59,7 +59,7 @@ async function fetchFileContent(url: string): Promise<string> {
 // Thanks to https://stackoverflow.com/questions/56658114/how-can-one-check-if-a-file-or-directory-exists-using-deno
 const fileExists = async (filename: string): Promise<boolean> => {
   try {
-    await Deno.stat(filename);
+    await Deno.stat(originalCWD + filename);
     // successful, file or directory must exist
     return true;
   } catch (error) {

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -194,14 +194,14 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/app.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/app_api.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
         // deps.ts
         Rhum.asserts.assertEquals(await fileExists("deps.ts"), true);
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/deps.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
@@ -211,7 +211,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/config.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
@@ -221,7 +221,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/resources/home_resource_api.ts",
         );
         copiedFile = getFileContent(
@@ -235,7 +235,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           ),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/tests/resources/home_resource_test.ts",
         );
         copiedFile = getFileContent(
@@ -285,7 +285,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/app.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/app_web_app.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
@@ -295,7 +295,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/deps.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/deps.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
@@ -305,7 +305,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/config.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
@@ -315,7 +315,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/resources/home_resource.ts",
         );
         copiedFile = getFileContent(
@@ -329,7 +329,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           ),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/tests/resources/home_resource_test.ts",
         );
         copiedFile = getFileContent(
@@ -341,7 +341,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/public/js/index.js"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/public/js/index.js",
         ),
           copiedFile = getFileContent(
@@ -353,7 +353,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/public/css/index.css"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/public/css/index.css",
         ),
           copiedFile = getFileContent(
@@ -365,7 +365,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/public/views/index.html"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/public/views/index.html",
         );
         copiedFile = getFileContent(
@@ -421,7 +421,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/app.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/app_web_app.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
@@ -431,7 +431,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/deps.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/deps.ts",
         ), copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -440,7 +440,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/config.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
@@ -450,7 +450,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/resources/home_resource.ts",
         );
         copiedFile = getFileContent(
@@ -464,7 +464,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           ),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/tests/resources/home_resource_test.ts",
         );
         copiedFile = getFileContent(
@@ -481,7 +481,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/webpack.config.js"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/webpack_vue.config.js",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/webpack.config.js");
@@ -491,7 +491,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/package.json"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/package_vue.json",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/package.json");
@@ -505,7 +505,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/vue/App.vue"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/vue/app.vue",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/vue/App.vue");
@@ -515,7 +515,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/vue/app.js"),
           true,
         );
-        boilerPlateFile = fetchFileContent(
+        boilerPlateFile = await fetchFileContent(
           "/console/create_app/vue/app.js",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/vue/app.js");

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -11,7 +11,10 @@ const tmpDirName = "tmp-dir-for-testing-create-app";
 let tmpDirNameCount = 10;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
-const drashUrl = "https://deno.land/x/drash@v1.x";
+const latestBranch = Deno.run({
+  cmd: ["git branch --show-current"]
+});
+const drashUrl = "https://deno.land/x/drash@" + latestBranch;
 
 function getOsCwd() {
   let cwd = `//${originalCWD}/console/create_app`;

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -59,8 +59,10 @@ async function fetchFileContent(url: string): Promise<string> {
 // Need a way to check if a file exists
 // Thanks to https://stackoverflow.com/questions/56658114/how-can-one-check-if-a-file-or-directory-exists-using-deno
 const fileExists = async (filename: string): Promise<boolean> => {
+  const fullFilepath = originalCWD + filename;
+  console.log(fullFilepath);
   try {
-    await Deno.stat(originalCWD + filename);
+    await Deno.stat(fullFilepath);
     // successful, file or directory must exist
     return true;
   } catch (error) {
@@ -200,7 +202,7 @@ Rhum.testPlan("create_app_test.ts", () => {
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
         // deps.ts
-        Rhum.asserts.assertEquals(await fileExists("deps.ts"), true);
+        Rhum.asserts.assertEquals(await fileExists("/deps.ts"), true);
         boilerPlateFile = await fetchFileContent(
           "/console/create_app/deps.ts",
         );

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -52,7 +52,7 @@ function getFileContent(filePathAndName: string): string {
  */
 async function fetchFileContent(url: string): Promise<string> {
   console.log(url);
-  const response = await fetch(url);
+  const response = await fetch(drashUrl + url);
   return await response.text();
 }
 
@@ -195,14 +195,14 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/app_api.ts",
+          "/console/create_app/app_api.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
         // deps.ts
         Rhum.asserts.assertEquals(await fileExists("deps.ts"), true);
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/deps.ts",
+          "/console/create_app/deps.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -212,7 +212,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/config.ts",
+          "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -222,7 +222,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/resources/home_resource_api.ts",
+          "/console/create_app/resources/home_resource_api.ts",
         );
         copiedFile = getFileContent(
           testCaseTmpDirName + "/resources/home_resource.ts",
@@ -236,8 +236,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD +
-            "/console/create_app/tests/resources/home_resource_test.ts",
+          "/console/create_app/tests/resources/home_resource_test.ts",
         );
         copiedFile = getFileContent(
           testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
@@ -287,7 +286,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/app_web_app.ts",
+          "/console/create_app/app_web_app.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -297,7 +296,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/deps.ts",
+          "/console/create_app/deps.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -307,7 +306,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/config.ts",
+          "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -317,7 +316,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/resources/home_resource.ts",
+          "/console/create_app/resources/home_resource.ts",
         );
         copiedFile = getFileContent(
           testCaseTmpDirName + "/resources/home_resource.ts",
@@ -331,8 +330,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD +
-            "/console/create_app/tests/resources/home_resource_test.ts",
+          "/console/create_app/tests/resources/home_resource_test.ts",
         );
         copiedFile = getFileContent(
           testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
@@ -344,7 +342,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/public/js/index.js",
+          "/console/create_app/public/js/index.js",
         ),
           copiedFile = getFileContent(
             testCaseTmpDirName + "/public/js/index.js",
@@ -356,7 +354,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/public/css/index.css",
+          "/console/create_app/public/css/index.css",
         ),
           copiedFile = getFileContent(
             testCaseTmpDirName + "/public/css/index.css",
@@ -368,7 +366,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/public/views/index.html",
+          "/console/create_app/public/views/index.html",
         );
         copiedFile = getFileContent(
           testCaseTmpDirName + "/public/views/index.html",
@@ -424,7 +422,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/app_web_app.ts",
+          "/console/create_app/app_web_app.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -434,7 +432,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/deps.ts",
+          "/console/create_app/deps.ts",
         ), copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
         // config.ts
@@ -443,7 +441,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/config.ts",
+          "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -453,7 +451,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/resources/home_resource.ts",
+          "/console/create_app/resources/home_resource.ts",
         );
         copiedFile = getFileContent(
           testCaseTmpDirName + "/resources/home_resource.ts",
@@ -467,8 +465,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD +
-            "/console/create_app/tests/resources/home_resource_test.ts",
+          "/console/create_app/tests/resources/home_resource_test.ts",
         );
         copiedFile = getFileContent(
           testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
@@ -485,7 +482,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/webpack_vue.config.js",
+          "/console/create_app/webpack_vue.config.js",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/webpack.config.js");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -495,7 +492,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/package_vue.json",
+          "/console/create_app/package_vue.json",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/package.json");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -509,7 +506,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/vue/app.vue",
+          "/console/create_app/vue/app.vue",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/vue/App.vue");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -519,7 +516,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
         boilerPlateFile = fetchFileContent(
-          originalCWD + "/console/create_app/vue/app.js",
+          "/console/create_app/vue/app.js",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/vue/app.js");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -1,0 +1,548 @@
+/**
+ * Test needs the following flags: --allow-read --allow-run --allow-write
+ *
+ * Will make a tmp directory in the root of this project, cd into it and create files there.
+ * This is only for some tests
+ */
+
+import { Rhum } from "../deps.ts";
+import { red, green } from "../../deps.ts";
+const tmpDirName = "tmp-dir-for-testing-create-app";
+let tmpDirNameCount = 0;
+const originalCWD = Deno.cwd();
+const decoder = new TextDecoder("utf-8");
+const drashUrl = "https://deno.land/x/drash@v1.x";
+
+function getOsCwd() {
+  let cwd = `//${originalCWD}/console/create_app`;
+  if (Deno.build.os === "windows") {
+    cwd = `${originalCWD}\console\create_app`;
+  }
+  return cwd;
+}
+
+function getOsTmpDirName() {
+  let tmp = `${originalCWD}/${tmpDirName}`;
+  if (Deno.build.os === "windows") {
+    tmp = `${originalCWD}\${tmpDirName}`;
+  }
+  return tmp;
+}
+
+/**
+ * To keep line endings consistent all on operating systems.
+ * Requires both the boilerplate and newly created files to get passed through this to ensure they are the same
+ * 
+ * @param string filename eg originCWD + "/console/create_app/app.ts" or tmpDir + "/app.ts"
+ */
+function getFileContent(filePathAndName: string): string {
+  const fileContent = decoder.decode(
+    Deno.readFileSync(filePathAndName),
+  ).replace(/\r\n/g, "\n");
+  return fileContent;
+}
+
+// Need a way to check if a file exists
+// Thanks to https://stackoverflow.com/questions/56658114/how-can-one-check-if-a-file-or-directory-exists-using-deno
+const fileExists = async (filename: string): Promise<boolean> => {
+  try {
+    await Deno.stat(filename);
+    // successful, file or directory must exist
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      // file or directory does not exist
+      return false;
+    } else {
+      // unexpected error, maybe permissions, pass it along
+      throw error;
+    }
+  }
+};
+
+Rhum.testPlan("create_app_test.ts", () => {
+  Rhum.testSuite("(no arguments passed in)", () => {
+    Rhum.testCase("script fails with no argument", async () => {
+      const p = Deno.run({
+        cmd: [
+          "deno",
+          "run",
+          "--allow-read",
+          "--allow-write",
+          "--allow-run",
+          drashUrl + "/create_app.ts",
+        ],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const status = await p.status();
+      p.close();
+      const stdout = new TextDecoder("utf-8").decode(await p.output());
+      const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+      Rhum.asserts.assertEquals(
+        stderr,
+        red(
+          "Too few options were given. Use the --help option for more information.",
+        ) + "\n",
+      );
+      Rhum.asserts.assertEquals(stdout, "");
+      Rhum.asserts.assertEquals(status.code, 1);
+      Rhum.asserts.assertEquals(status.success, false);
+    });
+  });
+
+  Rhum.testSuite("--help", () => {
+    Rhum.testCase("Script success with the --help argument", async () => {
+      const p = Deno.run({
+        cmd: [
+          "deno",
+          "run",
+          "--allow-read",
+          "--allow-write",
+          "--allow-run",
+          drashUrl + "/create_app.ts",
+          "--help",
+        ],
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const status = await p.status();
+      p.close();
+      const stdout = new TextDecoder("utf-8").decode(await p.output());
+      const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+      Rhum.asserts.assertEquals(stderr, "");
+      Rhum.asserts.assertEquals(
+        stdout,
+        "\n" +
+          "A create app script for Drash\n" +
+          "\n" +
+          "USAGE:\n" +
+          "    deno run --allow-read --allow-run [--allow-write --allow-net] create_app.ts [OPTIONS]\n" +
+          "    deno run --allow-read --allow-run [--allow-write --allow-net] https://deno.land/x/drash/create_app.ts [OPTIONS]\n" +
+          "\n" +
+          "OPTIONS:\n" +
+          "The --api and --web-app options cannot be used together.\n" +
+          "\n" +
+          "    --api\n" +
+          "        Creates the file structure and content for a Drash API.\n" +
+          "\n" +
+          "    --web-app\n" +
+          "        Creates the file structure and content for a Drash Web App.\n" +
+          "\n" +
+          "    --web-app --with-vue\n" +
+          "        Creates the file structure and content for a Drash Web App.\n" +
+          "        This options requires Node and npm because it uses Vue and webpack.\n" +
+          "\n" +
+          "EXAMPLE USAGE:\n" +
+          "    mkdir my-drash-api\n" +
+          "    cd my-drash-api\n" +
+          "    deno run --allow-read --allow-run --allow-write --allow-net https://deno.land/x/drash/create_app.ts --api\n" +
+          "\n",
+      );
+      Rhum.asserts.assertEquals(status.code, 0);
+      Rhum.asserts.assertEquals(status.success, true);
+    });
+  });
+
+  Rhum.testSuite("--api", () => {
+    Rhum.testCase(
+      "create_app_test.ts | Script creates an API project with the --api argument",
+      async () => {
+        const testCaseTmpDirName = tmpDirName + (tmpDirNameCount += 1);
+        // Create new tmp directory and create project files
+        Deno.mkdirSync(testCaseTmpDirName);
+        const p = Deno.run({
+          cmd: [
+            "deno",
+            "run",
+            "--allow-read",
+            "--allow-write",
+            "--allow-net",
+            "--allow-run",
+            drashUrl + "/create_app.ts",
+            "--api",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+          cwd: testCaseTmpDirName,
+        });
+        const status = await p.status();
+        p.close();
+        const stdout = new TextDecoder("utf-8").decode(await p.output());
+        const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+        Rhum.asserts.assertEquals(status.code, 0);
+        Rhum.asserts.assertEquals(status.success, true);
+        // assert each file and it's content are correct
+        let boilerPlateFile;
+        let copiedFile;
+        // app.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/app.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/app_api.ts",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // deps.ts
+        Rhum.asserts.assertEquals(await fileExists("deps.ts"), true);
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/deps.ts",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // config.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/config.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/config.ts",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // home_resource.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/resources/home_resource_api.ts",
+        );
+        copiedFile = getFileContent(
+          testCaseTmpDirName + "/resources/home_resource.ts",
+        );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // home_resource_test.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(
+            testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
+          ),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD +
+            "/console/create_app/tests/resources/home_resource_test.ts",
+        );
+        copiedFile = getFileContent(
+          testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
+        );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+      },
+    );
+  });
+
+  Rhum.testSuite("--web-app", () => {
+    Rhum.testCase(
+      "Script creates a web app with the --web-app argument",
+      async () => {
+        const testCaseTmpDirName = tmpDirName + (tmpDirNameCount += 1);
+        // Create new tmp directory and create project files
+        Deno.mkdirSync(testCaseTmpDirName);
+        const p = Deno.run({
+          cmd: [
+            "deno",
+            "run",
+            "--allow-read",
+            "--allow-write",
+            "--allow-net",
+            "--allow-run",
+            drashUrl + "/create_app.ts",
+            "--web-app",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+          cwd: testCaseTmpDirName,
+        });
+        const status = await p.status();
+        p.close();
+        const stdout = new TextDecoder("utf-8").decode(await p.output());
+        const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+        Rhum.asserts.assertEquals(stderr, "");
+        Rhum.asserts.assertEquals(status.code, 0);
+        Rhum.asserts.assertEquals(status.success, true);
+        // assert each file and it's content are correct
+        let boilerPlateFile;
+        let copiedFile;
+        // app.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/app.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/app_web_app.ts",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // deps.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/deps.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/deps.ts",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // config.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/config.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/config.ts",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // home_resource.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/resources/home_resource.ts",
+        );
+        copiedFile = getFileContent(
+          testCaseTmpDirName + "/resources/home_resource.ts",
+        );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // home_resource_test.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(
+            testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
+          ),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD +
+            "/console/create_app/tests/resources/home_resource_test.ts",
+        );
+        copiedFile = getFileContent(
+          testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
+        );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // public/views/js/index.js
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/public/js/index.js"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/public/js/index.js",
+        ),
+          copiedFile = getFileContent(
+            testCaseTmpDirName + "/public/js/index.js",
+          );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // public/css/index.css.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/public/css/index.css"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/public/css/index.css",
+        ),
+          copiedFile = getFileContent(
+            testCaseTmpDirName + "/public/css/index.css",
+          );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // public/views/index.html.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/public/views/index.html"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/public/views/index.html",
+        );
+        copiedFile = getFileContent(
+          testCaseTmpDirName + "/public/views/index.html",
+        );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // public/img.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/public/img"),
+          true,
+        );
+      },
+    );
+  });
+
+  Rhum.testSuite("--web-app --with-vue", () => {
+    Rhum.testCase(
+      "Script creates a web app with vue with the --web-app and --with-vue arguments",
+      async () => {
+        const testCaseTmpDirName = tmpDirName + (tmpDirNameCount += 1);
+        // Create new tmp directory and create project files
+        Deno.mkdirSync(testCaseTmpDirName);
+        const p = Deno.run({
+          cmd: [
+            "deno",
+            "run",
+            "--allow-read",
+            "--allow-write",
+            "--allow-net",
+            "--allow-run",
+            drashUrl + "/create_app.ts",
+            "--web-app",
+            "--with-vue",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+          cwd: testCaseTmpDirName,
+        });
+        const status = await p.status();
+        p.close();
+        const stdout = new TextDecoder("utf-8").decode(await p.output());
+        const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+        Rhum.asserts.assertEquals(stderr, "");
+        Rhum.asserts.assertEquals(status.code, 0);
+        Rhum.asserts.assertEquals(status.success, true);
+        // assert each file and it's content are correct
+        let boilerPlateFile;
+        let copiedFile;
+        // app.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/app.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/app_web_app.ts",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // deps.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/deps.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/deps.ts",
+        ), copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // config.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/config.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/config.ts",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // home_resource.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/resources/home_resource.ts",
+        );
+        copiedFile = getFileContent(
+          testCaseTmpDirName + "/resources/home_resource.ts",
+        );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // home_resource_test.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(
+            testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
+          ),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD +
+            "/console/create_app/tests/resources/home_resource_test.ts",
+        );
+        copiedFile = getFileContent(
+          testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
+        );
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // public/img.ts
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/public/img"),
+          true,
+        );
+        // webpack.config.js
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/webpack.config.js"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/webpack_vue.config.js",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/webpack.config.js");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // package.json
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/package.json"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/package_vue.json",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/package.json");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // vue/App.vue
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/vue"),
+          true,
+        );
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/vue/App.vue"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/vue/app.vue",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/vue/App.vue");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+        // vue/app.js
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/vue/app.js"),
+          true,
+        );
+        boilerPlateFile = getFileContent(
+          originalCWD + "/console/create_app/vue/app.js",
+        );
+        copiedFile = getFileContent(testCaseTmpDirName + "/vue/app.js");
+        Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+      },
+    );
+  });
+
+  Rhum.testSuite("--api and --web-app", () => {
+    Rhum.testCase(
+      "Script fails if --api and --web-app are specified",
+      async () => {
+        const p = Deno.run({
+          cmd: [
+            "deno",
+            "run",
+            "--allow-read",
+            "--allow-write",
+            "--allow-run",
+            drashUrl + "/create_app.ts",
+            "--api",
+            "--web-app",
+          ],
+          stdout: "piped",
+          stderr: "piped",
+        });
+        const status = await p.status();
+        p.close();
+        const stdout = new TextDecoder("utf-8").decode(await p.output());
+        const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+        Rhum.asserts.assertEquals(
+          stderr,
+          red(
+            "--web-app and --api options are not allowed to be used together. Use the --help option for more information.",
+          ) + "\n",
+        );
+        Rhum.asserts.assertEquals(stdout, "");
+        Rhum.asserts.assertEquals(status.code, 1);
+        Rhum.asserts.assertEquals(status.success, false);
+      },
+    );
+  });
+});
+
+Rhum.run();

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -94,9 +94,14 @@ Rhum.testPlan("create_app_test.ts", () => {
       const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
       Rhum.asserts.assertEquals(
         stderr,
-        red(
-          "Too few options were given. Use the --help option for more information.",
-        ) + "\n",
+        "Download https://deno.land/x/drash@" + latestBranch +
+          "/create_app.ts\n" +
+          "Download https://deno.land/x/drash@" + latestBranch + "/deps.ts\n" +
+          "Check https://deno.land/x/drash@" + latestBranch +
+          "/create_app.ts\n" +
+          red(
+            "Too few options were given. Use the --help option for more information.",
+          ) + "\n",
       );
       Rhum.asserts.assertEquals(stdout, "");
       Rhum.asserts.assertEquals(status.code, 1);
@@ -241,8 +246,6 @@ Rhum.testPlan("create_app_test.ts", () => {
           testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
         );
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
-
-        Deno.run({ cmd: ["rm -rf " + testCaseTmpDirName] });
       },
     );
   });
@@ -376,8 +379,6 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/public/img"),
           true,
         );
-
-        Deno.run({ cmd: ["rm -rf " + testCaseTmpDirName] });
       },
     );
   });
@@ -519,8 +520,6 @@ Rhum.testPlan("create_app_test.ts", () => {
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/vue/app.js");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
-
-        Deno.run({ cmd: ["rm -rf " + testCaseTmpDirName] });
       },
     );
   });

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -11,7 +11,7 @@ const tmpDirName = "tmp-dir-for-testing-create-app";
 let tmpDirNameCount = 10;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
-const latestBranch = Deno.env.get("CURRENT_BRANCH");
+const latestBranch = Deno.env.get("GITHUB_HEAD_REF");
 const drashUrl = "https://deno.land/x/drash@" + latestBranch;
 
 function getOsCwd() {

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -201,7 +201,10 @@ Rhum.testPlan("create_app_test.ts", () => {
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
         // deps.ts
-        Rhum.asserts.assertEquals(await fileExists(testCaseTmpDirName + "/deps.ts"), true);
+        Rhum.asserts.assertEquals(
+          await fileExists(testCaseTmpDirName + "/deps.ts"),
+          true,
+        );
         boilerPlateFile = await fetchFileContent(
           "/console/create_app/deps.ts",
         );

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -37,7 +37,7 @@ function getOsTmpDirName() {
  * @param string filename eg originCWD + "/console/create_app/app.ts" or tmpDir + "/app.ts"
  */
 function getFileContent(filePathAndName: string): string {
-  const fullFilepath = originalCWD + filePathAndName;
+  const fullFilepath = originalCWD + "/" + filePathAndName;
   const fileContent = decoder.decode(
     Deno.readFileSync(fullFilepath),
   ).replace(/\r\n/g, "\n");

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -11,9 +11,13 @@ const tmpDirName = "tmp-dir-for-testing-create-app";
 let tmpDirNameCount = 10;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
-const latestBranch = Deno.run({
-  cmd: ["git branch --show-current"]
-});
+const latestBranchP = Deno.run(
+  {
+    cmd: ["git", "branch", "--show-current"],
+    stdout: "piped"
+  }
+);
+const latestBranch = new TextDecoder("utf-8").decode(await latestBranchP.output());
 const drashUrl = "https://deno.land/x/drash@" + latestBranch;
 
 function getOsCwd() {
@@ -35,7 +39,7 @@ function getOsTmpDirName() {
 /**
  * To keep line endings consistent all on operating systems.
  * Requires both the boilerplate and newly created files to get passed through this to ensure they are the same
- * 
+ *
  * @param string filename eg originCWD + "/console/create_app/app.ts" or tmpDir + "/app.ts"
  */
 function getFileContent(filePathAndName: string): string {

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -38,7 +38,7 @@ function getOsTmpDirName() {
  */
 function getFileContent(filePathAndName: string): string {
   const fileContent = decoder.decode(
-    Deno.readFileSync(filePathAndName),
+    Deno.readFileSync(originalCWD + filePathAndName),
   ).replace(/\r\n/g, "\n");
   return fileContent;
 }
@@ -51,7 +51,6 @@ function getFileContent(filePathAndName: string): string {
  * Returns the contents of the fetched URL.
  */
 async function fetchFileContent(url: string): Promise<string> {
-  console.log(url);
   const response = await fetch(drashUrl + url);
   return await response.text();
 }

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -60,7 +60,6 @@ async function fetchFileContent(url: string): Promise<string> {
 // Thanks to https://stackoverflow.com/questions/56658114/how-can-one-check-if-a-file-or-directory-exists-using-deno
 const fileExists = async (filename: string): Promise<boolean> => {
   const fullFilepath = originalCWD + "/" + filename;
-  console.log(fullFilepath);
   try {
     await Deno.stat(fullFilepath);
     // successful, file or directory must exist

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -51,6 +51,7 @@ function getFileContent(filePathAndName: string): string {
  * Returns the contents of the fetched URL.
  */
 async function fetchFileContent(url: string): Promise<string> {
+  console.log(url);
   const response = await fetch(url);
   return await response.text();
 }

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -59,7 +59,7 @@ async function fetchFileContent(url: string): Promise<string> {
 // Need a way to check if a file exists
 // Thanks to https://stackoverflow.com/questions/56658114/how-can-one-check-if-a-file-or-directory-exists-using-deno
 const fileExists = async (filename: string): Promise<boolean> => {
-  const fullFilepath = originalCWD + filename;
+  const fullFilepath = originalCWD + "/" + filename;
   console.log(fullFilepath);
   try {
     await Deno.stat(fullFilepath);
@@ -202,7 +202,7 @@ Rhum.testPlan("create_app_test.ts", () => {
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
         // deps.ts
-        Rhum.asserts.assertEquals(await fileExists("/deps.ts"), true);
+        Rhum.asserts.assertEquals(await fileExists(testCaseTmpDirName + "/deps.ts"), true);
         boilerPlateFile = await fetchFileContent(
           "/console/create_app/deps.ts",
         );

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -11,13 +11,7 @@ const tmpDirName = "tmp-dir-for-testing-create-app";
 let tmpDirNameCount = 10;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
-const latestBranchP = Deno.run(
-  {
-    cmd: ["git", "branch", "--show-current"],
-    stdout: "piped"
-  }
-);
-const latestBranch = new TextDecoder("utf-8").decode(await latestBranchP.output());
+const latestBranch = Deno.env.get("CURRENT_BRANCH");
 const drashUrl = "https://deno.land/x/drash@" + latestBranch;
 
 function getOsCwd() {

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -8,7 +8,7 @@
 import { Rhum } from "../deps.ts";
 import { red, green } from "../../deps.ts";
 const tmpDirName = "tmp-dir-for-testing-create-app";
-let tmpDirNameCount = 0;
+let tmpDirNameCount = 10;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
 const drashUrl = "https://deno.land/x/drash@v1.x";

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -42,6 +42,18 @@ function getFileContent(filePathAndName: string): string {
   return fileContent;
 }
 
+/**
+ * Fetch contents from the URL provided.
+ *
+ * @param url
+ *
+ * Returns the contents of the fetched URL.
+ */
+async function fetchFileContent(url: string): Promise<string> {
+  const response = await fetch(url);
+  return await response.text();
+}
+
 // Need a way to check if a file exists
 // Thanks to https://stackoverflow.com/questions/56658114/how-can-one-check-if-a-file-or-directory-exists-using-deno
 const fileExists = async (filename: string): Promise<boolean> => {
@@ -146,7 +158,7 @@ Rhum.testPlan("create_app_test.ts", () => {
 
   Rhum.testSuite("--api", () => {
     Rhum.testCase(
-      "create_app_test.ts | Script creates an API project with the --api argument",
+      "Script creates an API project with the --api argument",
       async () => {
         const testCaseTmpDirName = tmpDirName + (tmpDirNameCount += 1);
         // Create new tmp directory and create project files
@@ -180,14 +192,14 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/app.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/app_api.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
         // deps.ts
         Rhum.asserts.assertEquals(await fileExists("deps.ts"), true);
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/deps.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
@@ -197,7 +209,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/config.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
@@ -207,7 +219,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/resources/home_resource_api.ts",
         );
         copiedFile = getFileContent(
@@ -221,7 +233,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           ),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD +
             "/console/create_app/tests/resources/home_resource_test.ts",
         );
@@ -229,6 +241,8 @@ Rhum.testPlan("create_app_test.ts", () => {
           testCaseTmpDirName + "/tests/resources/home_resource_test.ts",
         );
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+
+        Deno.run({cmd: ["rm -rf " + testCaseTmpDirName]});
       },
     );
   });
@@ -270,7 +284,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/app.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/app_web_app.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
@@ -280,7 +294,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/deps.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/deps.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
@@ -290,7 +304,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/config.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
@@ -300,7 +314,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/resources/home_resource.ts",
         );
         copiedFile = getFileContent(
@@ -314,7 +328,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           ),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD +
             "/console/create_app/tests/resources/home_resource_test.ts",
         );
@@ -327,7 +341,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/public/js/index.js"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/public/js/index.js",
         ),
           copiedFile = getFileContent(
@@ -339,7 +353,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/public/css/index.css"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/public/css/index.css",
         ),
           copiedFile = getFileContent(
@@ -351,7 +365,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/public/views/index.html"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/public/views/index.html",
         );
         copiedFile = getFileContent(
@@ -363,6 +377,8 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/public/img"),
           true,
         );
+
+        Deno.run({cmd: ["rm -rf " + testCaseTmpDirName]});
       },
     );
   });
@@ -405,7 +421,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/app.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/app_web_app.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/app.ts");
@@ -415,7 +431,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/deps.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/deps.ts",
         ), copiedFile = getFileContent(testCaseTmpDirName + "/deps.ts");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
@@ -424,7 +440,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/config.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/config.ts",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/config.ts");
@@ -434,7 +450,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/resources/home_resource.ts"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/resources/home_resource.ts",
         );
         copiedFile = getFileContent(
@@ -448,7 +464,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           ),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD +
             "/console/create_app/tests/resources/home_resource_test.ts",
         );
@@ -466,7 +482,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/webpack.config.js"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/webpack_vue.config.js",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/webpack.config.js");
@@ -476,7 +492,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/package.json"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/package_vue.json",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/package.json");
@@ -490,7 +506,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/vue/App.vue"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/vue/app.vue",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/vue/App.vue");
@@ -500,11 +516,13 @@ Rhum.testPlan("create_app_test.ts", () => {
           await fileExists(testCaseTmpDirName + "/vue/app.js"),
           true,
         );
-        boilerPlateFile = getFileContent(
+        boilerPlateFile = fetchFileContent(
           originalCWD + "/console/create_app/vue/app.js",
         );
         copiedFile = getFileContent(testCaseTmpDirName + "/vue/app.js");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
+
+        Deno.run({cmd: ["rm -rf " + testCaseTmpDirName]});
       },
     );
   });

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -242,7 +242,7 @@ Rhum.testPlan("create_app_test.ts", () => {
         );
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
 
-        Deno.run({cmd: ["rm -rf " + testCaseTmpDirName]});
+        Deno.run({ cmd: ["rm -rf " + testCaseTmpDirName] });
       },
     );
   });
@@ -378,7 +378,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           true,
         );
 
-        Deno.run({cmd: ["rm -rf " + testCaseTmpDirName]});
+        Deno.run({ cmd: ["rm -rf " + testCaseTmpDirName] });
       },
     );
   });
@@ -522,7 +522,7 @@ Rhum.testPlan("create_app_test.ts", () => {
         copiedFile = getFileContent(testCaseTmpDirName + "/vue/app.js");
         Rhum.asserts.assertEquals(boilerPlateFile, copiedFile);
 
-        Deno.run({cmd: ["rm -rf " + testCaseTmpDirName]});
+        Deno.run({ cmd: ["rm -rf " + testCaseTmpDirName] });
       },
     );
   });

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -95,10 +95,10 @@ Rhum.testPlan("create_app_test.ts", () => {
       const stdout = new TextDecoder("utf-8").decode(await p.output());
       const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
       Rhum.asserts.assertEquals(
-        stderr,
-        red(
+        stderr.includes(
           "Too few options were given. Use the --help option for more information.",
-        ) + "\n",
+        ),
+        true,
       );
       Rhum.asserts.assertEquals(stdout, "");
       Rhum.asserts.assertEquals(status.code, 1);

--- a/tests/cli/create_app_test_local.ts
+++ b/tests/cli/create_app_test_local.ts
@@ -7,11 +7,11 @@
 
 import { Rhum } from "../deps.ts";
 import { red, green } from "../../deps.ts";
-import members from "../members.ts";
 const tmpDirName = "tmp-dir-for-testing-create-app";
 let tmpDirNameCount = 0;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
+const drashUrl = "https://deno.land/x/drash@v1.x";
 
 function getOsCwd() {
   let cwd = `//${originalCWD}/console/create_app`;
@@ -70,7 +70,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           "--allow-read",
           "--allow-write",
           "--allow-run",
-          "create_app.ts",
+          drashUrl + "/create_app.ts",
         ],
         stdout: "piped",
         stderr: "piped",
@@ -100,7 +100,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           "--allow-read",
           "--allow-write",
           "--allow-run",
-          "create_app.ts",
+          drashUrl + "/create_app.ts",
           "--help",
         ],
         stdout: "piped",
@@ -159,7 +159,7 @@ Rhum.testPlan("create_app_test.ts", () => {
             "--allow-write",
             "--allow-net",
             "--allow-run",
-            "../create_app.ts",
+            drashUrl + "/create_app.ts",
             "--api",
           ],
           stdout: "piped",
@@ -248,7 +248,7 @@ Rhum.testPlan("create_app_test.ts", () => {
             "--allow-write",
             "--allow-net",
             "--allow-run",
-            "../create_app.ts",
+            drashUrl + "/create_app.ts",
             "--web-app",
           ],
           stdout: "piped",
@@ -382,7 +382,7 @@ Rhum.testPlan("create_app_test.ts", () => {
             "--allow-write",
             "--allow-net",
             "--allow-run",
-            "../create_app.ts",
+            drashUrl + "/create_app.ts",
             "--web-app",
             "--with-vue",
           ],
@@ -520,7 +520,7 @@ Rhum.testPlan("create_app_test.ts", () => {
             "--allow-read",
             "--allow-write",
             "--allow-run",
-            "create_app.ts",
+            drashUrl + "/create_app.ts",
             "--api",
             "--web-app",
           ],

--- a/tests/cli/create_app_test_local.ts
+++ b/tests/cli/create_app_test_local.ts
@@ -7,11 +7,11 @@
 
 import { Rhum } from "../deps.ts";
 import { red, green } from "../../deps.ts";
+import members from "../members.ts";
 const tmpDirName = "tmp-dir-for-testing-create-app";
 let tmpDirNameCount = 0;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
-const drashUrl = "https://deno.land/x/drash@v1.x";
 
 function getOsCwd() {
   let cwd = `//${originalCWD}/console/create_app`;
@@ -70,7 +70,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           "--allow-read",
           "--allow-write",
           "--allow-run",
-          drashUrl + "/create_app.ts",
+          "create_app.ts",
         ],
         stdout: "piped",
         stderr: "piped",
@@ -100,7 +100,7 @@ Rhum.testPlan("create_app_test.ts", () => {
           "--allow-read",
           "--allow-write",
           "--allow-run",
-          drashUrl + "/create_app.ts",
+          "create_app.ts",
           "--help",
         ],
         stdout: "piped",
@@ -159,7 +159,7 @@ Rhum.testPlan("create_app_test.ts", () => {
             "--allow-write",
             "--allow-net",
             "--allow-run",
-            drashUrl + "/create_app.ts",
+            "../create_app.ts",
             "--api",
           ],
           stdout: "piped",
@@ -248,7 +248,7 @@ Rhum.testPlan("create_app_test.ts", () => {
             "--allow-write",
             "--allow-net",
             "--allow-run",
-            drashUrl + "/create_app.ts",
+            "../create_app.ts",
             "--web-app",
           ],
           stdout: "piped",
@@ -382,7 +382,7 @@ Rhum.testPlan("create_app_test.ts", () => {
             "--allow-write",
             "--allow-net",
             "--allow-run",
-            drashUrl + "/create_app.ts",
+            "../create_app.ts",
             "--web-app",
             "--with-vue",
           ],
@@ -520,7 +520,7 @@ Rhum.testPlan("create_app_test.ts", () => {
             "--allow-read",
             "--allow-write",
             "--allow-run",
-            drashUrl + "/create_app.ts",
+            "create_app.ts",
             "--api",
             "--web-app",
           ],


### PR DESCRIPTION
Fixes #350 

**Description**

* When used as follows, it should fetch the contents from URLs and not try to read from folders it doesn't know about:

```
deno run --allow-read --allow-run --allow-write --allow-net https://deno.land/x/drash@v1.x/create_app.ts
```

**Other Notes**

* The issue was that `Deno.readFileSync()` was trying to do `Deno.readFileSync("http://deno.land/x/...")`. Instead, it should've been `await fetch("http://deno.land/x/...");`.
* The `create_app_test_http.ts` will fail because it's doesn't yet have the fix. It's fetching drash v1.x, but currently, drash v1.x doesn't have the fix. I can make the tests pass, but I'd have to change the branch name in the tests from v1.x to create-app-script-caching. Also, every time we update this script now (in regards to the HTTP version), the tests will most likely fail since it does a fetch call to outdated code.