### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,5 +12,5 @@ jobs:
      - run: |
           export PATH="/home/runner/.deno/bin:$PATH"
           eggs upgrade
-          eggs link --key ${{ secrets.CI_NESTLAND_API_KEY }}
+          eggs link ${{ secrets.CI_NESTLAND_API_KEY }}
           eggs publish


### PR DESCRIPTION
**Description**

* Fix release.yml, as newer versions of eggs dont use the `--key` option

**Other Notes**

* Note to self: release 1.2.3 manually after this is merged as the ci failed when doing it 