### PR TITLE
Add pr ci

### DIFF
--- a/.github/release_drafter_config.yml
+++ b/.github/release_drafter_config.yml
@@ -14,7 +14,15 @@ tag-template: 'v$RESOLVED_VERSION'
 #       - 'bug'
 #   - title: '🧰 Maintenance'
 #     label: 'chore'
+
 change-template: '- $TITLE (#$NUMBER)'
+
+# Only add to the draft release when a PR has one of these labels
+include-labels:
+  - 'major'
+  - 'minor'
+  - 'patch'
+  - 'chore'
 
 # Here is how we determine what version the release would be, by using labels. Eg when "minor" is used, the drafter knows to bump up to a new minor version
 version-resolver:
@@ -27,6 +35,7 @@ version-resolver:
   patch:
     labels:
       - 'patch'
+      - 'chore' # allow our chore PR's to just be patches too
   default: patch
 
 # What our release will look like. If no draft has been created, then this will be used, otherwise $CHANGES just gets addedd

--- a/.github/release_drafter_config.yml
+++ b/.github/release_drafter_config.yml
@@ -1,0 +1,48 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Used to group together pull requests. See the docs for more info, but we don't need this as we have our own custom format
+#categories:
+#   - title: '🚀 Features'
+#     labels:
+#       - 'feature'
+#       - 'enhancement'
+#   - title: '🐛 Bug Fixes'
+#     labels:
+#       - 'fix'
+#       - 'bugfix'
+#       - 'bug'
+#   - title: '🧰 Maintenance'
+#     label: 'chore'
+change-template: '- $TITLE (#$NUMBER)'
+
+# Here is how we determine what version the release would be, by using labels. Eg when "minor" is used, the drafter knows to bump up to a new minor version
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
+# What our release will look like. If no draft has been created, then this will be used, otherwise $CHANGES just gets addedd
+template: |
+  __Compatibility__
+
+  * Requires Deno v<DENO_VERSION> or higher
+  * Uses Deno std@<STD_VERSION>
+
+  __Importing__
+
+  * Import this latest release by using the following in your project(s):
+    ```typescript
+    import { Drash } from "https://deno.land/x/drash@v$RESOLVED_VERSION/mod.ts";
+    ```
+
+  __Updates__
+
+  $CHANGES

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          config-name: release_drafter_config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_USER_PAT }}


### PR DESCRIPTION
**Description**

* Adds a CI that automatically updates/creates a draft release for each merged PR

* Each repo has it's own 'variation' of release content, so actually with the templates for the release drafter, it makes it easier -  for example dmm's release content is slightly different

* On making a PR, make sure:
    * The title is in the format of "feat: <title>" or "fix: <title>". This is because the. PR title is what's shown in the release, and to support the feat/fix/etc prefix to changes, we do that here
    * Use the related labels. If pr is a patch (fix), use patch label, if a minor (feat) then use minor label, etc. If the PR isn't worth being mentioned in the release, then just leave the labels blanks, for example on readme updates

* When the PR is merged, the draft we get created if it isn't already, and will display all PR's merged since the last release

**Other Notes**

* It just mimics our current process, but instead:
    * it's automated
    * we must follow a format for pr titles and labels

* I haven't found a way yet we can dynamically use the Deno version in the template (see config i believe). It'd be good to do something like:
```
template: |
    * Uses Deno version v${latestDenoVersion}
```
```