### PR TITLE
chore: fix publish CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
      - uses: actions/checkout@v2
      - uses: denolib/setup-deno@master
-     - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.1.10/mod.ts
+     - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.2.2/mod.ts
      - run: |
           export PATH="/home/runner/.deno/bin:$PATH"
           eggs upgrade

--- a/egg.json
+++ b/egg.json
@@ -9,6 +9,10 @@
     "./deps.ts",
     "./create_app.ts",
     "./src/**/*",
-    "./README.md"
-  ]
+    "./README.md",
+    "./mod.ts"
+  ],
+  "entry": "/mod.ts",
+  "checkAll": false,
+  "unlisted": false
 }


### PR DESCRIPTION
Fixes [#<issue number>](url of issue)

**Description**

* Tonn of errors when the publish ci ran for 1.2.4, fixed by upgrading
* due to upgrading, the `egg.json` file needed updating too (new fields)
    * on top of this, i added `checkAll: false` because the testing eggs did failed, and i don't think we should write out our whole testing commands in that one line - plus, it's already tested