### PR TITLE
fix: Dont return null if body param is false; Support body params being data types other than a string

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -119,7 +119,7 @@ export class Request extends ServerRequest {
    *
    * @returns The corresponding parameter or null if not found
    */
-  public getBodyParam(input: string): string | null {
+  public getBodyParam(input: string): string | {[key: string]: unknown} | Array<unknown> | null {
     let param;
     if (typeof this.parsed_body.data!.value === "function") {
       // For when multipart/form-data

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -119,7 +119,7 @@ export class Request extends ServerRequest {
    *
    * @returns The corresponding parameter or null if not found
    */
-  public getBodyParam(input: string): string | {[key: string]: unknown} | Array<unknown> | null {
+  public getBodyParam(input: string): string | {[key: string]: unknown} | Array<unknown> | boolean | null {
     let param;
     if (typeof this.parsed_body.data!.value === "function") {
       // For when multipart/form-data
@@ -130,7 +130,7 @@ export class Request extends ServerRequest {
       // and typescript did not like us indexing.
       param = (this.parsed_body.data as { [k: string]: unknown })[input];
     }
-    if (param) {
+    if (param || typeof param === "boolean") {
       return param;
     }
     return null;

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -119,7 +119,9 @@ export class Request extends ServerRequest {
    *
    * @returns The corresponding parameter or null if not found
    */
-  public getBodyParam(input: string): string | {[key: string]: unknown} | Array<unknown> | boolean | null {
+  public getBodyParam(
+    input: string,
+  ): string | { [key: string]: unknown } | Array<unknown> | boolean | null {
     let param;
     if (typeof this.parsed_body.data!.value === "function") {
       // For when multipart/form-data

--- a/tests/integration/app_3000_resources/resources/coffee_resource.ts
+++ b/tests/integration/app_3000_resources/resources/coffee_resource.ts
@@ -14,7 +14,8 @@ export default class CoffeeResource extends Drash.Http.Resource {
   ]);
 
   public GET() {
-    let coffeeId = this.request.getPathParam("id");
+    // @ts-ignore Ignoring because we don't care
+    let coffeeId: any = this.request.getPathParam("id");
     const location = this.request.getUrlQueryParam("location");
     if (location) {
       if (location == "from_body") {

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -333,6 +333,67 @@ function getBodyParamTests() {
       await o.close();
     },
   );
+  // Before the date of 5th, Oct 2020, type errors were thrown for objects because the return value of `getBodyParam` was either a string or null
+  Rhum.testCase("Can handle when a body param is an object", async () => {
+    const body = encoder.encode(JSON.stringify({
+      user: {
+        name: "Edward",
+        location: "UK"
+      },
+    }));
+    const reader = new Deno.Buffer(body as ArrayBuffer);
+    const serverRequest = members.mockRequest("/", "get", {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: reader,
+    });
+    const request = new Drash.Http.Request(serverRequest);
+    await request.parseBody();
+    const actual = request.getBodyParam("user");
+    Rhum.asserts.assertEquals({
+      name: "Edward",
+      location: "UK"
+    }, actual);
+    const name = (actual as {[key: string]: unknown}).name // Ensuring we can access it and TS doesn't throw errors
+    Rhum.asserts.assertEquals(name, "Edward")
+  })
+  Rhum.testCase("Can handle when a body param is an array", async () => {
+    const body = encoder.encode(JSON.stringify({
+      usernames: ["Edward", "John Smith", "Lord Voldemort", "Count Dankula"]
+    }));
+    const reader = new Deno.Buffer(body as ArrayBuffer);
+    const serverRequest = members.mockRequest("/", "get", {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: reader,
+    });
+    const request = new Drash.Http.Request(serverRequest);
+    await request.parseBody();
+    const actual = request.getBodyParam("usernames");
+    Rhum.asserts.assertEquals(["Edward", "John Smith", "Lord Voldemort", "Count Dankula"], actual);
+    const firstName = (actual as Array<string>)[0]
+    Rhum.asserts.assertEquals(firstName, "Edward")
+  })
+  Rhum.testCase("Can handle when a body param is a boolean", async () => {
+    const body = encoder.encode(JSON.stringify({
+      authenticated: true
+    }));
+    const reader = new Deno.Buffer(body as ArrayBuffer);
+    const serverRequest = members.mockRequest("/", "get", {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: reader,
+    });
+    const request = new Drash.Http.Request(serverRequest);
+    await request.parseBody();
+    const actual = request.getBodyParam("authenticated");
+    Rhum.asserts.assertEquals(false, actual);
+    const authenticated = (actual as boolean)
+    Rhum.asserts.assertEquals(authenticated, false)
+  })
 }
 
 function getHeaderParamTests() {

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -378,7 +378,7 @@ function getBodyParamTests() {
   })
   Rhum.testCase("Can handle when a body param is a boolean", async () => {
     const body = encoder.encode(JSON.stringify({
-      authenticated: true
+      authenticated: false
     }));
     const reader = new Deno.Buffer(body as ArrayBuffer);
     const serverRequest = members.mockRequest("/", "get", {
@@ -390,7 +390,7 @@ function getBodyParamTests() {
     const request = new Drash.Http.Request(serverRequest);
     await request.parseBody();
     const actual = request.getBodyParam("authenticated");
-    Rhum.asserts.assertEquals(false, actual);
+    Rhum.asserts.assertEquals(actual, false);
     const authenticated = (actual as boolean)
     Rhum.asserts.assertEquals(authenticated, false)
   })

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -338,7 +338,7 @@ function getBodyParamTests() {
     const body = encoder.encode(JSON.stringify({
       user: {
         name: "Edward",
-        location: "UK"
+        location: "UK",
       },
     }));
     const reader = new Deno.Buffer(body as ArrayBuffer);
@@ -353,14 +353,14 @@ function getBodyParamTests() {
     const actual = request.getBodyParam("user");
     Rhum.asserts.assertEquals({
       name: "Edward",
-      location: "UK"
+      location: "UK",
     }, actual);
-    const name = (actual as {[key: string]: unknown}).name // Ensuring we can access it and TS doesn't throw errors
-    Rhum.asserts.assertEquals(name, "Edward")
-  })
+    const name = (actual as { [key: string]: unknown }).name; // Ensuring we can access it and TS doesn't throw errors
+    Rhum.asserts.assertEquals(name, "Edward");
+  });
   Rhum.testCase("Can handle when a body param is an array", async () => {
     const body = encoder.encode(JSON.stringify({
-      usernames: ["Edward", "John Smith", "Lord Voldemort", "Count Dankula"]
+      usernames: ["Edward", "John Smith", "Lord Voldemort", "Count Dankula"],
     }));
     const reader = new Deno.Buffer(body as ArrayBuffer);
     const serverRequest = members.mockRequest("/", "get", {
@@ -372,13 +372,16 @@ function getBodyParamTests() {
     const request = new Drash.Http.Request(serverRequest);
     await request.parseBody();
     const actual = request.getBodyParam("usernames");
-    Rhum.asserts.assertEquals(["Edward", "John Smith", "Lord Voldemort", "Count Dankula"], actual);
-    const firstName = (actual as Array<string>)[0]
-    Rhum.asserts.assertEquals(firstName, "Edward")
-  })
+    Rhum.asserts.assertEquals(
+      ["Edward", "John Smith", "Lord Voldemort", "Count Dankula"],
+      actual,
+    );
+    const firstName = (actual as Array<string>)[0];
+    Rhum.asserts.assertEquals(firstName, "Edward");
+  });
   Rhum.testCase("Can handle when a body param is a boolean", async () => {
     const body = encoder.encode(JSON.stringify({
-      authenticated: false
+      authenticated: false,
     }));
     const reader = new Deno.Buffer(body as ArrayBuffer);
     const serverRequest = members.mockRequest("/", "get", {
@@ -391,9 +394,9 @@ function getBodyParamTests() {
     await request.parseBody();
     const actual = request.getBodyParam("authenticated");
     Rhum.asserts.assertEquals(actual, false);
-    const authenticated = (actual as boolean)
-    Rhum.asserts.assertEquals(authenticated, false)
-  })
+    const authenticated = (actual as boolean);
+    Rhum.asserts.assertEquals(authenticated, false);
+  });
 }
 
 function getHeaderParamTests() {


### PR DESCRIPTION
Fixes #384 and #378

**Description**

* Passing in a body param that is false will not return null, and instead return it's expected value
* Assume that a body param can be of any type and not just a string