### PR TITLE
chore: Send request to website on release to update versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,7 @@ jobs:
           eggs upgrade
           eggs link ${{ secrets.CI_NESTLAND_API_KEY }}
           eggs publish
+
+     - name: Send Event to Website to Update Versions
+       run: |
+         curl -XPOST -u "${{ secrets.CI_USER_NAME }}:${{ secrets.CI_USER_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/drashland/website/dispatches --data '{"event_type": "update_docs", "client_payload": { "module_to_update": "drash", "version": "${{ github.event.release.tag_name }}" }}'


### PR DESCRIPTION
**Description**

* On releasing, send a github event to the website repo so it can automate the process of updating the drash versions
