### PR TITLE
fix: Content length was 2 when content type is JSON and body is empty

### DIFF
--- a/src/http/response.ts
+++ b/src/http/response.ts
@@ -196,7 +196,7 @@ export class Response {
 
     switch (contentType) {
       case "application/json":
-        return JSON.stringify(this.body);
+        return this.body ? JSON.stringify(this.body) : "";
       case "application/xml":
       case "text/html":
       case "text/xml":


### PR DESCRIPTION
**Description**

* Found as part of getting cors middleware to work. Content length on response was 2 even when body was empty. This is because (see code changes), when `this.body` is empty, and you try `JSON.stringify` it, the result will be:
```
console.log(JSON.stringify("")) // """"
```
It essentially adds data and thus a body. So the body is **actually** empty, but when it comes to encoding that, it's a Uint8Array with a length of four, because we are pretty much doing `new TextEncoder().encode('""')`, which is wrong

![image](https://user-images.githubusercontent.com/47337480/97118633-fa33bc00-1702-11eb-8477-b9fec69a5efe.png)
