### PR TITLE
feat: Add getAll methods for header, body and path params

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -153,12 +153,12 @@ export class Request extends ServerRequest {
    *
    * @return Key value pairs for the header name and it's value
    */
-  public getAllHeaderParams (): {[key: string]: string} {
-    let headers: {[key: string]: string} = {}
+  public getAllHeaderParams(): { [key: string]: string } {
+    let headers: { [key: string]: string } = {};
     for (const pair of this.headers.entries()) {
-      headers[pair[0]] = pair[1]
+      headers[pair[0]] = pair[1];
     }
-    return headers
+    return headers;
   }
 
   /**
@@ -166,10 +166,10 @@ export class Request extends ServerRequest {
    *
    * @return The parsed body as an object
    */
-  public getAllBodyParams (): Drash.Interfaces.ParsedRequestBody {
-    console.log('the body:')
-    console.log(this.parsed_body)
-    return this.parsed_body
+  public getAllBodyParams(): Drash.Interfaces.ParsedRequestBody {
+    console.log("the body:");
+    console.log(this.parsed_body);
+    return this.parsed_body;
   }
 
   /**

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -9,6 +9,7 @@ import {
 } from "../../deps.ts";
 type Reader = Deno.Reader;
 import { Drash } from "../../mod.ts";
+
 const decoder = new TextDecoder();
 const encoder = new TextEncoder();
 
@@ -145,6 +146,30 @@ export class Request extends ServerRequest {
    */
   public getHeaderParam(input: string): string | null {
     return this.headers.get(input);
+  }
+
+  /**
+   * Gets all header params
+   *
+   * @return Key value pairs for the header name and it's value
+   */
+  public getAllHeaderParams (): {[key: string]: string} {
+    let headers: {[key: string]: string} = {}
+    for (const pair of this.headers.entries()) {
+      headers[pair[0]] = pair[1]
+    }
+    return headers
+  }
+
+  /**
+   * Gets all the body params
+   *
+   * @return The parsed body as an object
+   */
+  public getAllBodyParams (): Drash.Interfaces.ParsedRequestBody {
+    console.log('the body:')
+    console.log(this.parsed_body)
+    return this.parsed_body
   }
 
   /**

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -456,25 +456,25 @@ function getAllBodyParamsTests() {
   );
 }
 
-function getAllPathParamsTests() {
-  Rhum.testCase(
-    "Returns all of the path parameters",
-    async () => {
-      const serverRequest = members.mockRequest();
-      const request = new Drash.Http.Request(serverRequest);
-      await request.parseBody();
-      request.path_params = {
-        hello: "world",
-        goodbye: "world",
-      };
-      //const actual = request.getAllPathParams();
-      // Rhum.asserts.assertEquals(actual, {
-      //   hello: "world",
-      //   goodbye: "world"
-      // });
-    },
-  );
-}
+// function getAllPathParamsTests() {
+//   Rhum.testCase(
+//     "Returns all of the path parameters",
+//     async () => {
+//       const serverRequest = members.mockRequest();
+//       const request = new Drash.Http.Request(serverRequest);
+//       await request.parseBody();
+//       request.path_params = {
+//         hello: "world",
+//         goodbye: "world",
+//       };
+//       const actual = request.getAllPathParams();
+//       Rhum.asserts.assertEquals(actual, {
+//         hello: "world",
+//         goodbye: "world"
+//       });
+//     },
+//   );
+// }
 
 function getHeaderParamTests() {
   Rhum.testCase(

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -92,6 +92,14 @@ Rhum.testPlan("http/request_test.ts", () => {
     getUrlQueryStringTests();
   });
 
+  Rhum.testSuite("getAllHeaderParams()", () => {
+    getAllHeaderParamsTests();
+  });
+
+  Rhum.testSuite("getAllBodyParams()", () => {
+    getAllBodyParamsTests();
+  });
+
   Rhum.testSuite("hasBody()", () => {
     hasBodyTests();
   });
@@ -397,6 +405,75 @@ function getBodyParamTests() {
     const authenticated = (actual as boolean);
     Rhum.asserts.assertEquals(authenticated, false);
   });
+}
+
+function getAllHeaderParamsTests () {
+  Rhum.testCase(
+      "Returns all the header params",
+      async () => {
+        const serverRequest = members.mockRequest("/", "get", {
+          headers: {
+            hello: "world",
+          },
+        });
+        const request = new Drash.Http.Request(serverRequest);
+        const actual = request.getAllHeaderParams();
+        Rhum.asserts.assertEquals(actual, {
+          hello: "world"
+        });
+      },
+  );
+}
+
+function getAllBodyParamsTests () {
+  Rhum.testCase(
+      "Returns the value for the header param when it exists",
+      async () => {
+        const data = {
+          name: "Ed",
+          age: 22
+        }
+        const body = encoder.encode(JSON.stringify(data));
+        const reader = new Deno.Buffer(body as ArrayBuffer);
+        const serverRequest = members.mockRequest("/", "get", {
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length":  JSON.stringify(data).length
+          },
+          body: reader
+        });
+        const request = new Drash.Http.Request(serverRequest);
+        await request.parseBody();
+        const actual = request.getAllBodyParams();
+        Rhum.asserts.assertEquals(actual, {
+          content_type: "application/json",
+          data: {
+            age: 22,
+            name: "Ed"
+          }
+        })
+      },
+  );
+}
+
+function getAllPathParamsTests () {
+  Rhum.testCase(
+      "Returns all of the path parameters",
+      async () => {
+        const serverRequest = members.mockRequest();
+        const request = new Drash.Http.Request(serverRequest);
+        await request.parseBody();
+        request.path_params = {
+          hello: "world",
+          goodbye: "world"
+        };
+        //const actual = request.getAllPathParams();
+        // Rhum.asserts.assertEquals(actual, {
+        //   hello: "world",
+        //   goodbye: "world"
+        // });
+      },
+  );
 }
 
 function getHeaderParamTests() {

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -407,72 +407,72 @@ function getBodyParamTests() {
   });
 }
 
-function getAllHeaderParamsTests () {
+function getAllHeaderParamsTests() {
   Rhum.testCase(
-      "Returns all the header params",
-      async () => {
-        const serverRequest = members.mockRequest("/", "get", {
-          headers: {
-            hello: "world",
-          },
-        });
-        const request = new Drash.Http.Request(serverRequest);
-        const actual = request.getAllHeaderParams();
-        Rhum.asserts.assertEquals(actual, {
-          hello: "world"
-        });
-      },
-  );
-}
-
-function getAllBodyParamsTests () {
-  Rhum.testCase(
-      "Returns the value for the header param when it exists",
-      async () => {
-        const data = {
-          name: "Ed",
-          age: 22
-        }
-        const body = encoder.encode(JSON.stringify(data));
-        const reader = new Deno.Buffer(body as ArrayBuffer);
-        const serverRequest = members.mockRequest("/", "get", {
-          headers: {
-            "Content-Type": "application/json",
-            "Content-Length":  JSON.stringify(data).length
-          },
-          body: reader
-        });
-        const request = new Drash.Http.Request(serverRequest);
-        await request.parseBody();
-        const actual = request.getAllBodyParams();
-        Rhum.asserts.assertEquals(actual, {
-          content_type: "application/json",
-          data: {
-            age: 22,
-            name: "Ed"
-          }
-        })
-      },
-  );
-}
-
-function getAllPathParamsTests () {
-  Rhum.testCase(
-      "Returns all of the path parameters",
-      async () => {
-        const serverRequest = members.mockRequest();
-        const request = new Drash.Http.Request(serverRequest);
-        await request.parseBody();
-        request.path_params = {
+    "Returns all the header params",
+    async () => {
+      const serverRequest = members.mockRequest("/", "get", {
+        headers: {
           hello: "world",
-          goodbye: "world"
-        };
-        //const actual = request.getAllPathParams();
-        // Rhum.asserts.assertEquals(actual, {
-        //   hello: "world",
-        //   goodbye: "world"
-        // });
-      },
+        },
+      });
+      const request = new Drash.Http.Request(serverRequest);
+      const actual = request.getAllHeaderParams();
+      Rhum.asserts.assertEquals(actual, {
+        hello: "world",
+      });
+    },
+  );
+}
+
+function getAllBodyParamsTests() {
+  Rhum.testCase(
+    "Returns the value for the header param when it exists",
+    async () => {
+      const data = {
+        name: "Ed",
+        age: 22,
+      };
+      const body = encoder.encode(JSON.stringify(data));
+      const reader = new Deno.Buffer(body as ArrayBuffer);
+      const serverRequest = members.mockRequest("/", "get", {
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": JSON.stringify(data).length,
+        },
+        body: reader,
+      });
+      const request = new Drash.Http.Request(serverRequest);
+      await request.parseBody();
+      const actual = request.getAllBodyParams();
+      Rhum.asserts.assertEquals(actual, {
+        content_type: "application/json",
+        data: {
+          age: 22,
+          name: "Ed",
+        },
+      });
+    },
+  );
+}
+
+function getAllPathParamsTests() {
+  Rhum.testCase(
+    "Returns all of the path parameters",
+    async () => {
+      const serverRequest = members.mockRequest();
+      const request = new Drash.Http.Request(serverRequest);
+      await request.parseBody();
+      request.path_params = {
+        hello: "world",
+        goodbye: "world",
+      };
+      //const actual = request.getAllPathParams();
+      // Rhum.asserts.assertEquals(actual, {
+      //   hello: "world",
+      //   goodbye: "world"
+      // });
+    },
   );
 }
 


### PR DESCRIPTION
Addresses #382 

**Description**

* Adds method to get all header params

* Adds method to get all body params

**Other Notes**
* Decided against the get all path params, as i can't figure out a solution atm, should we still merge this PR? it only provides 2 out of the 3 methods it was supposed to
