### PR TITLE
bugfix: Made a mistake when trying to fix deno url

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,10 +41,10 @@ jobs:
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      # Commented out since this doesn't work on forks of main repository
-      # - name: Create App (http)
-      #   run: |
-      #     deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
+      Commented out since this doesn't work on forks of main repository
+      - name: Create App (http)
+        run: |
+          deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net
 
   linter:
     # Only one OS is required since fmt is cross platform

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,7 +41,6 @@ jobs:
           deno cache create_app.ts
           deno test tests/cli/create_app_test_local.ts --allow-read --allow-write --allow-run --allow-env
 
-      Commented out since this doesn't work on forks of main repository
       - name: Create App (http)
         run: |
           deno test tests/cli/create_app_test_http.ts --allow-read --allow-write --allow-run --allow-env --allow-net

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -19,11 +19,11 @@ if (!latestBranch) {
 }
 
 if (!githubRepo) {
-  githubRepo = "drashland/deno-land";
+  githubRepo = "drashland/deno-drash";
 }
 
-const drashUrl = "https://raw.githubusercontent.com/" + githubRepo +
-  `/${latestBranch}`;
+const drashUrl =
+  `https://raw.githubusercontent.com/${githubRepo}/${latestBranch}`;
 
 function getOsCwd() {
   let cwd = `//${originalCWD}/console/create_app`;
@@ -176,6 +176,7 @@ Rhum.testPlan("create_app_test.ts", () => {
       async () => {
         const testCaseTmpDirName = tmpDirName + (tmpDirNameCount += 1);
         // Create new tmp directory and create project files
+        console.log(`${testCaseTmpDirName}`);
         Deno.mkdirSync(testCaseTmpDirName);
         const p = Deno.run({
           cmd: [

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -14,12 +14,9 @@ const decoder = new TextDecoder("utf-8");
 let latestBranch = Deno.env.get("GITHUB_HEAD_REF");
 let githubRepo = Deno.env.get("GITHUB_REPOSITORY");
 
-if (!latestBranch) {
-  latestBranch = "master";
-}
-
-if (!githubRepo) {
+if (!githubRepo || !latestBranch) {
   githubRepo = "drashland/deno-drash";
+  latestBranch = "master";
 }
 
 const drashUrl =

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -14,12 +14,20 @@ const decoder = new TextDecoder("utf-8");
 const githubRepo = Deno.env.get("GITHUB_REPOSITORY") ?? "drashland/deno-drash";
 let latestBranch = Deno.env.get("GITHUB_HEAD_REF") ?? "master";
 
+console.log("START");
+console.log(latestBranch);
+console.log(githubRepo);
+console.log(Deno.env.get("GITHUB_BASE_REF"));
+console.log("END");
+
 let drashUrl =
   `https://raw.githubusercontent.com/${githubRepo}/${latestBranch}`;
 
-await fetch(drashUrl + "/create_app.ts").catch((error) => {
+try {
+  await fetch(drashUrl + "/create_app.ts");
+} catch {
   drashUrl = "https://raw.githubusercontent.com/drashland/deno-drash/master";
-});
+}
 
 function getOsCwd() {
   let cwd = `//${originalCWD}/console/create_app`;

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -17,7 +17,7 @@ let latestBranch = Deno.env.get("GITHUB_HEAD_REF") ?? "master";
 let drashUrl =
   `https://raw.githubusercontent.com/${githubRepo}/${latestBranch}`;
 
-fetch(drashUrl + "/create_app.ts").catch((error) => {
+await fetch(drashUrl + "/create_app.ts").catch((error) => {
   drashUrl = "https://raw.githubusercontent.com/drashland/deno-drash/master";
 });
 

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -7,32 +7,19 @@
 
 import { Rhum } from "../deps.ts";
 import { green, red } from "../../deps.ts";
-import { Octokit } from "../deps.ts";
 const tmpDirName = "tmp-dir-for-testing-create-app";
 let tmpDirNameCount = 10;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
 const githubRepo = Deno.env.get("GITHUB_REPOSITORY") ?? "drashland/deno-drash";
-const [owner, repo] = githubRepo.split("/");
 let latestBranch = Deno.env.get("GITHUB_HEAD_REF") ?? "master";
 
-const octokit = new Octokit();
+let drashUrl =
+  `https://raw.githubusercontent.com/${githubRepo}/${latestBranch}`;
 
-await octokit.repos.listBranches({
-  owner: owner,
-  repo: repo,
-}).then((branches: any) => {
-  if (
-    !branches.data?.find((branch: any) => {
-      branch.name === latestBranch;
-    })
-  ) {
-    latestBranch = "master";
-  }
+fetch(drashUrl + "/create_app.ts").catch((error) => {
+  drashUrl = "https://raw.githubusercontent.com/drashland/deno-drash/master";
 });
-
-const drashUrl =
-  `https://raw.githubusercontent.com/${owner}/${repo}/${latestBranch}`;
 
 function getOsCwd() {
   let cwd = `//${originalCWD}/console/create_app`;

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -11,22 +11,22 @@ const tmpDirName = "tmp-dir-for-testing-create-app";
 let tmpDirNameCount = 10;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
-const githubRepo = Deno.env.get("GITHUB_REPOSITORY") ?? "drashland/deno-drash";
-let latestBranch = Deno.env.get("GITHUB_HEAD_REF") ?? "master";
 
-console.log("START");
-console.log(latestBranch);
-console.log(githubRepo);
-console.log(Deno.env.get("GITHUB_BASE_REF"));
-console.log("END");
-
+const githubRepo = Deno.env.get("GITHUB_REPOSITORY");
+const latestBranch = Deno.env.get("GITHUB_HEAD_REF");
 let drashUrl =
   `https://raw.githubusercontent.com/${githubRepo}/${latestBranch}`;
+// https://raw.githubusercontent.com/<NAME>/deno-drash/<branch>
 
+// if fork doesnt exist, use drashland repo, eg name might be ebebbington, but i dont have a fork
 try {
-  await fetch(drashUrl + "/create_app.ts");
-} catch {
-  drashUrl = "https://raw.githubusercontent.com/drashland/deno-drash/master";
+  const res = await fetch(drashUrl);
+  await res.json();
+  if (res.status !== 200) {
+    drashUrl = "https://raw.githubusercontent.com/drashland/deno-drash/master";
+  }
+} catch (err) {
+  // do nothing
 }
 
 function getOsCwd() {

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -13,6 +13,7 @@ const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
 let latestBranch = Deno.env.get("GITHUB_HEAD_REF");
 let githubRepo = Deno.env.get("GITHUB_REPOSITORY");
+console.log(`{ Repo: ${githubRepo}, Branch: ${latestBranch} }`)
 
 if (!githubRepo || !latestBranch) {
   githubRepo = "drashland/deno-drash";

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -13,7 +13,6 @@ const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
 let latestBranch = Deno.env.get("GITHUB_HEAD_REF");
 let githubRepo = Deno.env.get("GITHUB_REPOSITORY");
-console.log(`{ Repo: ${githubRepo}, Branch: ${latestBranch} }`);
 
 if (!githubRepo || !latestBranch) {
   githubRepo = "drashland/deno-drash";
@@ -103,6 +102,7 @@ Rhum.testPlan("create_app_test.ts", () => {
       p.close();
       const stdout = new TextDecoder("utf-8").decode(await p.output());
       const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
+      console.log(`{ Repo: ${githubRepo}, Branch: ${latestBranch} }`);
       Rhum.asserts.assertEquals(
         stderr.includes(
           "Too few options were given. Use the --help option for more information.",

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -13,7 +13,7 @@ const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
 let latestBranch = Deno.env.get("GITHUB_HEAD_REF");
 let githubRepo = Deno.env.get("GITHUB_REPOSITORY");
-console.log(`{ Repo: ${githubRepo}, Branch: ${latestBranch} }`)
+console.log(`{ Repo: ${githubRepo}, Branch: ${latestBranch} }`);
 
 if (!githubRepo || !latestBranch) {
   githubRepo = "drashland/deno-drash";

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -12,21 +12,17 @@ let tmpDirNameCount = 10;
 const originalCWD = Deno.cwd();
 const decoder = new TextDecoder("utf-8");
 
-const githubRepo = Deno.env.get("GITHUB_REPOSITORY");
-const latestBranch = Deno.env.get("GITHUB_HEAD_REF");
+const githubRepo = Deno.env.get("GITHUB_REPOSITORY") ?? "drashland/deno-drash";
+const latestBranch = Deno.env.get("GITHUB_HEAD_REF") ?? "master";
 let drashUrl =
   `https://raw.githubusercontent.com/${githubRepo}/${latestBranch}`;
 // https://raw.githubusercontent.com/<NAME>/deno-drash/<branch>
 
 // if fork doesnt exist, use drashland repo, eg name might be ebebbington, but i dont have a fork
 try {
-  const res = await fetch(drashUrl);
-  await res.json();
-  if (res.status !== 200) {
-    drashUrl = "https://raw.githubusercontent.com/drashland/deno-drash/master";
-  }
-} catch (err) {
-  // do nothing
+  await fetch(drashUrl + `/${latestBranch}`);
+} catch {
+  drashUrl = "https://raw.githubusercontent.com/drashland/deno-drash/master";
 }
 
 function getOsCwd() {

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -176,7 +176,6 @@ Rhum.testPlan("create_app_test.ts", () => {
       async () => {
         const testCaseTmpDirName = tmpDirName + (tmpDirNameCount += 1);
         // Create new tmp directory and create project files
-        console.log(`${testCaseTmpDirName}`);
         Deno.mkdirSync(testCaseTmpDirName);
         const p = Deno.run({
           cmd: [

--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -14,10 +14,12 @@ const decoder = new TextDecoder("utf-8");
 let latestBranch = Deno.env.get("GITHUB_HEAD_REF");
 let githubRepo = Deno.env.get("GITHUB_REPOSITORY");
 
+/*
 if (!githubRepo || !latestBranch) {
   githubRepo = "drashland/deno-drash";
   latestBranch = "master";
 }
+*/
 
 const drashUrl =
   `https://raw.githubusercontent.com/${githubRepo}/${latestBranch}`;

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -4,3 +4,5 @@ export {
   isFormFile,
   MultipartReader,
 } from "https://deno.land/std@0.74.0/mime/multipart.ts";
+
+export { Octokit } from "https://cdn.skypack.dev/@octokit/rest";

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -4,5 +4,3 @@ export {
   isFormFile,
   MultipartReader,
 } from "https://deno.land/std@0.74.0/mime/multipart.ts";
-
-export { Octokit } from "https://cdn.skypack.dev/@octokit/rest";


### PR DESCRIPTION
The official repo name was drashland/deno-drash,
but for some reason, I wrote drashland/deno-land.
My bad.

Fixes [#403 ]

**Description**

