### PR TITLE
feat: Throw an error if response is not correctly returned from resource

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -24,11 +24,12 @@ interface IRequestOptions {
  * Used to check if a response object is of type Drash.Interfaces.ResponseOutput
  */
 // @ts-ignore Only exception because response cannot be properly typed and we're checking if it is of type interface anyway
-function responseIsOfTypeResponseOutput (response: any): boolean {
+function responseIsOfTypeResponseOutput(response: any): boolean {
   if (typeof response === "object" && Array.isArray(response) === false) {
-    return "status" in response && "headers" in response && "body" in response && "send" in response && "status_code" in response
+    return "status" in response && "headers" in response &&
+      "body" in response && "send" in response && "status_code" in response;
   }
-  return false
+  return false;
 }
 
 /**
@@ -271,9 +272,15 @@ export class Server {
       response = await resource[request.method.toUpperCase()](); // response can  be literally anything, it's down to the user what they return from the method
 
       // Check the response was returned as the Drash.Http.Response type, or as ResponseOutput
-      const isValidResponse = response instanceof Drash.Http.Response === true || responseIsOfTypeResponseOutput(response) === true
+      const isValidResponse =
+        response instanceof Drash.Http.Response === true ||
+        responseIsOfTypeResponseOutput(response) === true;
       if (isValidResponse === false) {
-        throw new Drash.Exceptions.HttpResponseException(418, "The response must be returned inside the " + request.method.toUpperCase() + " method of the resource")
+        throw new Drash.Exceptions.HttpResponseException(
+          418,
+          "The response must be returned inside the " +
+            request.method.toUpperCase() + " method of the resource",
+        );
       }
 
       await this.executeMiddlewareServerLevelAfterRequest(request, response);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -261,7 +261,7 @@ export class Server {
       response = await resource[request.method.toUpperCase()]();
 
       // Check the response was returned as the Drash.Http.Response type, or as ResponseOutput
-      const isValidResponse = this.isValidResponse(response)
+      const isValidResponse = this.isValidResponse(response);
       if (isValidResponse === false) {
         throw new Drash.Exceptions.HttpResponseException(
           418,
@@ -831,7 +831,6 @@ export class Server {
     this.logger.debug("[syslog] " + message);
   }
 
-
   /**
    * Used to check if a response object is of type Drash.Interfaces.ResponseOutput
    * or Drash.Http.Response.
@@ -839,17 +838,20 @@ export class Server {
    * @return If the response returned from a method is what the returned value should be
    */
   // @ts-ignore Only exception because response cannot be properly typed and we're checking if it is of type interface or response anyway
-  protected isValidResponse (response: any) {
+  protected isValidResponse(response: any) {
     // Method to aid inn checking is ann interface (Drash.Interface.ResponseOutput)
     function responseIsOfTypeResponseOutput(response: any): boolean {
-      if (typeof response === "object" && Array.isArray(response) === false && response !== null) {
+      if (
+        typeof response === "object" && Array.isArray(response) === false &&
+        response !== null
+      ) {
         return "status" in response && "headers" in response &&
-            "body" in response && "send" in response && "status_code" in response;
+          "body" in response && "send" in response && "status_code" in response;
       }
       return false;
     }
     const valid = response instanceof Drash.Http.Response ||
-    responseIsOfTypeResponseOutput(response) === true;
-    return valid
+      responseIsOfTypeResponseOutput(response) === true;
+    return valid;
   }
 }

--- a/tests/integration/app_3000_resources/resources/returning_invalid_response_in_resource.ts
+++ b/tests/integration/app_3000_resources/resources/returning_invalid_response_in_resource.ts
@@ -1,0 +1,11 @@
+import { Drash } from "../../../../mod.ts";
+
+export default class InvalidReturningOfResponseResource extends Drash.Http.Resource {
+  static paths = ["/invalid/returning/of/response"]
+  public GET() {
+
+  }
+  public POST() {
+    return "hello"
+  }
+}

--- a/tests/integration/app_3000_resources/resources/returning_invalid_response_in_resource.ts
+++ b/tests/integration/app_3000_resources/resources/returning_invalid_response_in_resource.ts
@@ -1,11 +1,11 @@
 import { Drash } from "../../../../mod.ts";
 
-export default class InvalidReturningOfResponseResource extends Drash.Http.Resource {
-  static paths = ["/invalid/returning/of/response"]
+export default class InvalidReturningOfResponseResource
+  extends Drash.Http.Resource {
+  static paths = ["/invalid/returning/of/response"];
   public GET() {
-
   }
   public POST() {
-    return "hello"
+    return "hello";
   }
 }

--- a/tests/integration/app_3000_resources/returning_invalid_response_in_resource_test.ts
+++ b/tests/integration/app_3000_resources/returning_invalid_response_in_resource_test.ts
@@ -15,26 +15,30 @@ Rhum.testPlan("coffee_resource_test.ts", () => {
     Rhum.testCase("Error is thrown when nothing is returned", async () => {
       await runServer(server);
 
-      const response = await members.fetch.get("http://localhost:3000/invalid/returning/of/response");
+      const response = await members.fetch.get(
+        "http://localhost:3000/invalid/returning/of/response",
+      );
       await server.close();
 
       Rhum.asserts.assertEquals(
         await response.text(),
         '"The response must be returned inside the GET method of the resource"',
       );
-      Rhum.asserts.assertEquals(response.status, 418)
+      Rhum.asserts.assertEquals(response.status, 418);
     });
     Rhum.testCase("Error is thrown when nothing is returned", async () => {
       await runServer(server);
 
-      const response = await members.fetch.post("http://localhost:3000/invalid/returning/of/response");
+      const response = await members.fetch.post(
+        "http://localhost:3000/invalid/returning/of/response",
+      );
       await server.close();
 
       Rhum.asserts.assertEquals(
-          await response.text(),
-          '"The response must be returned inside the POST method of the resource"',
+        await response.text(),
+        '"The response must be returned inside the POST method of the resource"',
       );
-      Rhum.asserts.assertEquals(response.status, 418)
+      Rhum.asserts.assertEquals(response.status, 418);
     });
   });
 });

--- a/tests/integration/app_3000_resources/returning_invalid_response_in_resource_test.ts
+++ b/tests/integration/app_3000_resources/returning_invalid_response_in_resource_test.ts
@@ -1,0 +1,42 @@
+import members from "../../members.ts";
+import { Rhum } from "../../deps.ts";
+import { Drash } from "../../../mod.ts";
+import InvalidReturningOfResponseResource from "./resources/returning_invalid_response_in_resource.ts";
+import { runServer } from "../test_utils.ts";
+
+const server = new Drash.Http.Server({
+  resources: [
+    InvalidReturningOfResponseResource,
+  ],
+});
+
+Rhum.testPlan("coffee_resource_test.ts", () => {
+  Rhum.testSuite("/invalid/returning/of/response", () => {
+    Rhum.testCase("Error is thrown when nothing is returned", async () => {
+      await runServer(server);
+
+      const response = await members.fetch.get("http://localhost:3000/invalid/returning/of/response");
+      await server.close();
+
+      Rhum.asserts.assertEquals(
+        await response.text(),
+        '"The response must be returned inside the GET method of the resource"',
+      );
+      Rhum.asserts.assertEquals(response.status, 418)
+    });
+    Rhum.testCase("Error is thrown when nothing is returned", async () => {
+      await runServer(server);
+
+      const response = await members.fetch.post("http://localhost:3000/invalid/returning/of/response");
+      await server.close();
+
+      Rhum.asserts.assertEquals(
+          await response.text(),
+          '"The response must be returned inside the POST method of the resource"',
+      );
+      Rhum.asserts.assertEquals(response.status, 418)
+    });
+  });
+});
+
+Rhum.run();

--- a/tests/integration/app_3000_resources/tests.ts
+++ b/tests/integration/app_3000_resources/tests.ts
@@ -7,4 +7,4 @@ import "./files_resource_test.ts";
 import "./users_resource_test.ts";
 import "./optional_path_params_test.ts";
 import "./browser_request_resource_test.ts";
-import "./returning_invalid_response_in_resource_test.ts"
+import "./returning_invalid_response_in_resource_test.ts";

--- a/tests/integration/app_3000_resources/tests.ts
+++ b/tests/integration/app_3000_resources/tests.ts
@@ -7,3 +7,4 @@ import "./files_resource_test.ts";
 import "./users_resource_test.ts";
 import "./optional_path_params_test.ts";
 import "./browser_request_resource_test.ts";
+import "./returning_invalid_response_in_resource_test.ts"

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -449,6 +449,44 @@ Rhum.testPlan("http/server_test.ts", () => {
       Rhum.asserts.assert(!server.deno_server);
     });
   });
+
+  Rhum.testSuite("isValidResponse()", () => {
+    Rhum.testCase("Should check that the response object is valid", () => {
+      const server = new Drash.Http.Server({})
+      const isValidResponse = Reflect.get(server, "isValidResponse")
+      //Simulate user not returning properly inside their resource method
+      const possiblesInvalidResponse = [
+          "hello",
+          true,
+          1,
+        { name: "Ed"},
+          ["hello"],
+          null,
+          undefined
+      ]
+      possiblesInvalidResponse.forEach(invalidRes => {
+        const isValid = isValidResponse(invalidRes)
+        Rhum.asserts.assertEquals(isValid, false)
+      })
+      const responseOutput: Drash.Interfaces.ResponseOutput = {
+        body: new Uint8Array(1),
+        headers: new Headers(),
+        status: 69420,
+        status_code: 418,
+        send: undefined
+      };
+      const request = new  Drash.Http.Request(members.mockRequest('/hello'))
+      const response: Drash.Http.Response = new Drash.Http.Response(request, {})
+      const validResponses = [
+          responseOutput,
+          response
+      ]
+      validResponses.forEach(validRes => {
+        const isValid = isValidResponse(validRes)
+        Rhum.asserts.assertEquals(isValid, true)
+      })
+    })
+  })
 });
 
 Rhum.run();

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -452,41 +452,44 @@ Rhum.testPlan("http/server_test.ts", () => {
 
   Rhum.testSuite("isValidResponse()", () => {
     Rhum.testCase("Should check that the response object is valid", () => {
-      const server = new Drash.Http.Server({})
-      const isValidResponse = Reflect.get(server, "isValidResponse")
+      const server = new Drash.Http.Server({});
+      const isValidResponse = Reflect.get(server, "isValidResponse");
       //Simulate user not returning properly inside their resource method
       const possiblesInvalidResponse = [
-          "hello",
-          true,
-          1,
-        { name: "Ed"},
-          ["hello"],
-          null,
-          undefined
-      ]
-      possiblesInvalidResponse.forEach(invalidRes => {
-        const isValid = isValidResponse(invalidRes)
-        Rhum.asserts.assertEquals(isValid, false)
-      })
+        "hello",
+        true,
+        1,
+        { name: "Ed" },
+        ["hello"],
+        null,
+        undefined,
+      ];
+      possiblesInvalidResponse.forEach((invalidRes) => {
+        const isValid = isValidResponse(invalidRes);
+        Rhum.asserts.assertEquals(isValid, false);
+      });
       const responseOutput: Drash.Interfaces.ResponseOutput = {
         body: new Uint8Array(1),
         headers: new Headers(),
         status: 69420,
         status_code: 418,
-        send: undefined
+        send: undefined,
       };
-      const request = new  Drash.Http.Request(members.mockRequest('/hello'))
-      const response: Drash.Http.Response = new Drash.Http.Response(request, {})
+      const request = new Drash.Http.Request(members.mockRequest("/hello"));
+      const response: Drash.Http.Response = new Drash.Http.Response(
+        request,
+        {},
+      );
       const validResponses = [
-          responseOutput,
-          response
-      ]
-      validResponses.forEach(validRes => {
-        const isValid = isValidResponse(validRes)
-        Rhum.asserts.assertEquals(isValid, true)
-      })
-    })
-  })
+        responseOutput,
+        response,
+      ];
+      validResponses.forEach((validRes) => {
+        const isValid = isValidResponse(validRes);
+        Rhum.asserts.assertEquals(isValid, true);
+      });
+    });
+  });
 });
 
 Rhum.run();

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -175,6 +175,18 @@ Rhum.testPlan("http/server_test.ts", () => {
         "/notes/1557",
       );
     });
+
+    Rhum.testCase("Throws an error when the response was not returned in the resource", async () => {
+      const server = new Drash.Http.Server({
+        resources: [InvalidReturningOfResponseResource],
+      });
+      let request = members.mockRequest("/invalid/returning/of/response");
+      let response = await server.handleHttpRequest(request);
+      Rhum.asserts.assertEquals(response.status_code, 418);
+      request = members.mockRequest("/invalid/returning/of/response", "POST");
+      response = await server.handleHttpRequest(request);
+      Rhum.asserts.assertEquals(response.status_code, 418);
+    });
   });
 
   Rhum.testSuite("handleHttpRequestError()", () => {
@@ -474,6 +486,16 @@ class NotesResource extends Drash.Http.Resource {
     }
     this.response.body = { note_id: noteId };
     return this.response;
+  }
+}
+
+class InvalidReturningOfResponseResource extends Drash.Http.Resource {
+  static paths = ["/invalid/returning/of/response"]
+  public GET() {
+
+  }
+  public POST() {
+    return "hello"
   }
 }
 

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -176,17 +176,20 @@ Rhum.testPlan("http/server_test.ts", () => {
       );
     });
 
-    Rhum.testCase("Throws an error when the response was not returned in the resource", async () => {
-      const server = new Drash.Http.Server({
-        resources: [InvalidReturningOfResponseResource],
-      });
-      let request = members.mockRequest("/invalid/returning/of/response");
-      let response = await server.handleHttpRequest(request);
-      Rhum.asserts.assertEquals(response.status_code, 418);
-      request = members.mockRequest("/invalid/returning/of/response", "POST");
-      response = await server.handleHttpRequest(request);
-      Rhum.asserts.assertEquals(response.status_code, 418);
-    });
+    Rhum.testCase(
+      "Throws an error when the response was not returned in the resource",
+      async () => {
+        const server = new Drash.Http.Server({
+          resources: [InvalidReturningOfResponseResource],
+        });
+        let request = members.mockRequest("/invalid/returning/of/response");
+        let response = await server.handleHttpRequest(request);
+        Rhum.asserts.assertEquals(response.status_code, 418);
+        request = members.mockRequest("/invalid/returning/of/response", "POST");
+        response = await server.handleHttpRequest(request);
+        Rhum.asserts.assertEquals(response.status_code, 418);
+      },
+    );
   });
 
   Rhum.testSuite("handleHttpRequestError()", () => {
@@ -490,12 +493,11 @@ class NotesResource extends Drash.Http.Resource {
 }
 
 class InvalidReturningOfResponseResource extends Drash.Http.Resource {
-  static paths = ["/invalid/returning/of/response"]
+  static paths = ["/invalid/returning/of/response"];
   public GET() {
-
   }
   public POST() {
-    return "hello"
+    return "hello";
   }
 }
 


### PR DESCRIPTION
Fixes #402 

**Description**

* If the data returned from a method is not of type Response or ResponseOutput, throw an error