### PR TITLE
feat: getAllPathParams()

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -176,7 +176,7 @@ export class Request extends ServerRequest {
    * @return A key-value pair object where the key is the param name and the
    * value is the param value.
    */
-  public getAllPathParams(): {[key: string]: string} {
+  public getAllPathParams(): { [key: string]: string } {
     return this.path_params;
   }
 

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -167,8 +167,6 @@ export class Request extends ServerRequest {
    * @return The parsed body as an object
    */
   public getAllBodyParams(): Drash.Interfaces.ParsedRequestBody {
-    console.log("the body:");
-    console.log(this.parsed_body);
     return this.parsed_body;
   }
 

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -171,6 +171,16 @@ export class Request extends ServerRequest {
   }
 
   /**
+   * Get all the path params.
+   *
+   * @return A key-value pair object where the key is the param name and the
+   * value is the param value.
+   */
+  public getAllPathParams(): {[key: string]: string} {
+    return this.path_params;
+  }
+
+  /**
    * Get the value of one of this request's path params by its input name.
    *
    * @returns The corresponding path parameter or null if not found.

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -100,6 +100,10 @@ Rhum.testPlan("http/request_test.ts", () => {
     getAllBodyParamsTests();
   });
 
+  Rhum.testSuite("getAllPathParams()", () => {
+    getAllPathParamsTests();
+  });
+
   Rhum.testSuite("hasBody()", () => {
     hasBodyTests();
   });
@@ -452,6 +456,23 @@ function getAllBodyParamsTests() {
           name: "Ed",
         },
       });
+    },
+  );
+}
+
+function getAllPathParamsTests() {
+  Rhum.testCase(
+    "Returns all path params",
+    async () => {
+      const expected = {
+        param_1: "user",
+        param_2: "name"
+      };
+      const serverRequest = members.mockRequest("/user/name", "get");
+      const request = new Drash.Http.Request(serverRequest);
+      request.path_params = expected;
+      const actual = request.getAllPathParams();
+      Rhum.asserts.assertEquals(actual, expected);
     },
   );
 }

--- a/tests/unit/http/request_test.ts
+++ b/tests/unit/http/request_test.ts
@@ -466,7 +466,7 @@ function getAllPathParamsTests() {
     async () => {
       const expected = {
         param_1: "user",
-        param_2: "name"
+        param_2: "name",
       };
       const serverRequest = members.mockRequest("/user/name", "get");
       const request = new Drash.Http.Request(serverRequest);
@@ -476,26 +476,6 @@ function getAllPathParamsTests() {
     },
   );
 }
-
-// function getAllPathParamsTests() {
-//   Rhum.testCase(
-//     "Returns all of the path parameters",
-//     async () => {
-//       const serverRequest = members.mockRequest();
-//       const request = new Drash.Http.Request(serverRequest);
-//       await request.parseBody();
-//       request.path_params = {
-//         hello: "world",
-//         goodbye: "world",
-//       };
-//       const actual = request.getAllPathParams();
-//       Rhum.asserts.assertEquals(actual, {
-//         hello: "world",
-//         goodbye: "world"
-//       });
-//     },
-//   );
-// }
 
 function getHeaderParamTests() {
   Rhum.testCase(


### PR DESCRIPTION
**Description**

@ebebbington, i think the reason you weren't able to test this properly was because you were using `parseBody()` when that method only applies to body params. the `server.getResourceClass()` method is where we assign `request.path_params`. for example, we do this in `server.getResourceClass()`:

```
request.path_params = { "some_param": "some_value" }
```

this happens when the resource is found and before the resource's HTTP method is executed, so that means `request.path_params` is ready to be used inside the resource's HTTP methods.