### PR TITLE
fix: create app http tests

### DIFF
--- a/tests/cli/create_app_test_http.ts
+++ b/tests/cli/create_app_test_http.ts
@@ -9,7 +9,10 @@ import { Rhum } from "../deps.ts";
 import { green, red } from "../../deps.ts";
 import { testMethods } from "./test_methods.ts";
 
-const branch = Deno.env.get("GITHUB_HEAD_REF") ?? "master";
+let branch = Deno.env.get("GITHUB_HEAD_REF");
+if (!branch || branch.trim() == "") {
+  branch = "master";
+}
 const githubOwner = Deno.env.get("GITHUB_ACTOR") ?? "drashland"; // possible it's the user and not drashland
 const repository = "deno-drash";
 // supports forks
@@ -30,4 +33,9 @@ try {
   // do nothing
 }
 
-testMethods("http", drashUrl);
+testMethods("http", {
+  base_url: drashUrl,
+  branch: branch,
+  github_owner: githubOwner,
+  repository: repository,
+});

--- a/tests/cli/test_methods.ts
+++ b/tests/cli/test_methods.ts
@@ -81,7 +81,6 @@ export function testMethods(
   const createAppLocation = baseUrl + "/create_app.ts";
 
   Rhum.testPlan("create_app_test_" + suffix + ".ts / url: " + baseUrl, () => {
-
     // console.log(options); // uncomment this for debugging purposes
 
     let boilerPlateFile: string;

--- a/tests/cli/test_methods.ts
+++ b/tests/cli/test_methods.ts
@@ -66,11 +66,24 @@ const fileExists = async (filename: string): Promise<boolean> => {
   }
 };
 
-export function testMethods(suffix: "local" | "http", url?: string) {
-  const baseUrl = url ? url : "..";
+interface ITestOptions {
+  base_url?: string;
+  branch?: string;
+  github_owner?: string;
+  repository?: string;
+}
+
+export function testMethods(
+  suffix: "local" | "http",
+  options: ITestOptions = {},
+) {
+  const baseUrl = options.base_url ?? "..";
   const createAppLocation = baseUrl + "/create_app.ts";
 
-  Rhum.testPlan("create_app_test_" + suffix + ".ts", () => {
+  Rhum.testPlan("create_app_test_" + suffix + ".ts / url: " + baseUrl, () => {
+
+    // console.log(options); // uncomment this for debugging purposes
+
     let boilerPlateFile: string;
     let copiedFile: string;
 


### PR DESCRIPTION
## Summary

* makes sure `master` is set if `Deno.env.get("GITHUB_HEAD_REF")` returns a falsy value or `""`.