### PR TITLE
chore: Notify middleware repo on new drash releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,15 @@ jobs:
             -H "Content-Type: application/json" \
             --data '{"event_type": "release", "client_payload": { "repo": "deno-drash", "module": "drash", "version": "${{ github.ref }}" }}' \
             https://api.github.com/repos/drashland/castle/dispatches
+
+  update-middleware-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Middleware about this release
+        run: |
+          curl -X POST \
+            -u "${{ secrets.CI_USER_NAME }}:${{ secrets.CI_USER_PAT }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" \
+            --data '{"event_type": "release", "client_payload": { "repo": "deno-drash", "module": "drash" }}' \
+            https://api.github.com/repos/drashland/deno-drash-middleware/dispatches


### PR DESCRIPTION
## Summary

Part 1 of 2

* Sends an event to the middleware repo on a release. This will be used by the middleware repo to bump it's dependencies, and hopefully pre-release (part 2)
* Why? We found that to make middleware usable, the drash version it uses has to be the same as the one a user uses, so say a user is using latest of drash (1.4.2), and uses middleare too, but the middleware uses drash v1.4.1, this is incompatible and will throw an error. So with this PR, we're making sure that when drash releases a new version, we release a new middleware version right away that uses the latest of drash
