### PR TITLE
chore: Support before request middleware wanting to end req lifecycle

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -140,7 +140,7 @@ export class Server {
     let response = this.buildResponse(request);
 
     try {
-      await this.executeMiddlewareBeforeRequest(request);
+      await this.executeMiddlewareBeforeRequest(request, response);
 
       // Is this request for the favicon?
       if (request.url == "/favicon.ico") {
@@ -833,10 +833,11 @@ export class Server {
    */
   protected async executeMiddlewareBeforeRequest(
     request: Drash.Http.Request,
+    response: Drash.Http.Response
   ): Promise<void> {
     if (this.middleware.before_request != null) {
       for (const middleware of this.middleware.before_request) {
-        await middleware(request);
+        await middleware(request, response);
       }
     }
   }

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -833,7 +833,7 @@ export class Server {
    */
   protected async executeMiddlewareBeforeRequest(
     request: Drash.Http.Request,
-    response: Drash.Http.Response
+    response: Drash.Http.Response,
   ): Promise<void> {
     if (this.middleware.before_request != null) {
       for (const middleware of this.middleware.before_request) {

--- a/src/interfaces/server_middleware.ts
+++ b/src/interfaces/server_middleware.ts
@@ -61,7 +61,10 @@ export interface ServerMiddleware {
   // Middleware executed before a request is made. That is, before a resource's
   // HTTP method is called.
   before_request?: Array<
-    | ((request: Drash.Http.Request, response: Drash.Http.Response) => Promise<void>)
+    | ((
+      request: Drash.Http.Request,
+      response: Drash.Http.Response,
+    ) => Promise<void>)
     | ((request: Drash.Http.Request, response: Drash.Http.Response) => void)
   >;
 

--- a/src/interfaces/server_middleware.ts
+++ b/src/interfaces/server_middleware.ts
@@ -61,8 +61,8 @@ export interface ServerMiddleware {
   // Middleware executed before a request is made. That is, before a resource's
   // HTTP method is called.
   before_request?: Array<
-    | ((request: Drash.Http.Request) => Promise<void>)
-    | ((request: Drash.Http.Request) => void)
+    | ((request: Drash.Http.Request, response: Drash.Http.Response) => Promise<void>)
+    | ((request: Drash.Http.Request, response: Drash.Http.Response) => void)
   >;
 
   // Middleware executed after requests, but before responses are sent


### PR DESCRIPTION
Address the issue found here: drashland/deno-drash-middleware#97 (comment)

I tested a local version of RateLimit and it worked fine

I also believe in the middleware functions, they could just call "response.send()" if they want to end the request lifecycle, as opposed to drash adding logic to control this
