### PR TITLE
Start constructing tests; use es priv for more server methods

### DIFF
--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -4,11 +4,11 @@ export type ParsedBody = Record<string, FormDataEntryValue> | null | Record<stri
 
 // TODO(crookse TODO-DOCBLOCK) Add docblock.
 export class DrashRequest extends Request {
-  #original!: Request;
+  #original: Request;
   #parsed_body?: ParsedBody;
   #path_params: Map<string, string> = new Map();
   #resource!: Drash.DrashResource;
-  #search_params: Map<string, string> = new Map()
+  #search_params?: URLSearchParams
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - CONSTRUCTOR /////////////////////////////////////////////////
@@ -82,7 +82,7 @@ export class DrashRequest extends Request {
    */
   public params(
     type: "body" | "path" | "query"
-  ): ParsedBody | Map<string, string> {
+  ): ParsedBody | Map<string, string> | URLSearchParams {
     switch(type) {
       case "body":
         return this.#parsed_body ?? null;
@@ -93,17 +93,8 @@ export class DrashRequest extends Request {
         }
         return this.#path_params;
       case "query":
-        if (!this.#search_params.size) {
-          const searchStr = this.url.split("?")
-          searchStr.shift()
-          if (!searchStr.length) {
-            this.#search_params = new Map()
-          }
-          const params = searchStr[0].split("&")
-          for (const param of params) {
-            const [name, value] = param.split("=")
-            this.#search_params.set(name, value)
-          }
+        if (!this.#search_params) {
+          this.#search_params = new URL(this.#original.url).searchParams
         }
         return this.#search_params;
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -233,7 +233,7 @@ export interface IServerOptions {
   };
   port?: number;
   protocol: "http" | "https";
-  resources?: typeof Drash.DrashResource[];
+  resources: typeof Drash.DrashResource[];
   services?: {
     // Services executed before a request is made (before a resource is found).
     before_request?: typeof Drash.Service[],

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -232,7 +232,7 @@ export interface IServerOptions {
     multipart_form_data: number,
   };
   port?: number;
-  protocol?: "http" | "https";
+  protocol: "http" | "https";
   resources?: typeof Drash.DrashResource[];
   services?: {
     // Services executed before a request is made (before a resource is found).

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -2,6 +2,8 @@ export { Rhum } from "https://deno.land/x/rhum@v1.1.10/mod.ts";
 export * as Drash from "../mod.ts";
 export * as path from "https://deno.land/std@0.99.0/path/mod.ts";
 export * as TestHelpers from "./test_helpers.ts";
+export { assertThrowsAsync } from "https://deno.land/std@0.104.0/testing/asserts.ts";
+
 export {
   isFormFile,
   MultipartReader,

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -111,7 +111,7 @@ class HomeResource extends DrashResource {
     return this.response;
   }
   public POST() {
-    this.response.body = this.request.body;
+    this.response.body = JSON.stringify(this.request.params('body'));
     return this.response;
   }
 }

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -1,302 +1,51 @@
-import { Drash, Rhum, TestHelpers } from "../../../../deps.ts";
+import { Drash, Rhum, TestHelpers } from "../../deps.ts";
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+import { Server } from "../../../src/http/server.ts"
+import { assertThrowsAsync } from "../../deps.ts"
 
 Rhum.testPlan("http/server_test.ts", () => {
-  Rhum.testSuite("handleHttpRequest()", () => {
-    Rhum.testCase("request.url == /favicon.ico", async () => {
-      const server = new Drash.Server({
-        resources: [HomeResource],
-      });
-      const request = TestHelpers.mockRequest("/favicon.ico");
-      const response = await server.handleHttpRequest(request);
-      Rhum.asserts.assertEquals(200, response.status_code);
-    });
+  Rhum.testSuite("constructor()", () => {
+    Rhum.testCase("Sets properties on the class correctly", () => {
+      const server = new Server({
+        port: 1234,
+      })
+      Rhum.asserts.assertEquals(server.options, {
+        // TODO
+      })
+    })
+  })
 
-    Rhum.testCase("GET", async () => {
-      const server = new Drash.Server({
-        resources: [HomeResource],
-      });
-      let request = TestHelpers.mockRequest("/");
-      let response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(
-        decoder.decode(response.body as ArrayBuffer),
-        { body: "got" },
-      );
-    });
+  Rhum.testSuite("address", () => {
+    Rhum.testCase("Should correctly format the address", () => {
+      const server1 = new Server({ protocol: "https", hostname: "hosty" ,port: 1234 })
+      const server2 = new Server({ port: 1234 })
+      Rhum.asserts.assertEquals(server1.address, "https://hosty:1234")
+      Rhum.asserts.assertEquals(server2.address, "http://localhost:1234")
+    })
+  })
 
-    Rhum.testCase("GET /:some_param", async () => {
-      const server = new Drash.Server({
-        resources: [HomeResource],
-      });
-      let request = TestHelpers.mockRequest("/w00t");
-      let response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(
-        decoder.decode(response.body as ArrayBuffer),
-        { body: "w00t" },
-      );
-    });
-
-    Rhum.testCase("POST", async () => {
-      const server = new Drash.Server({
-        resources: [HomeResource],
-      });
-      const body = encoder.encode(JSON.stringify({
-        body_param: "hello",
-      }));
-      const reader = new Deno.Buffer(body as ArrayBuffer);
-      const request = TestHelpers.mockRequest("/", "post", {
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: reader,
-      });
-      const response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(
-        decoder.decode(response.body as ArrayBuffer),
-        { body: "hello" },
-      );
-    });
-
-    Rhum.testCase("getPathParam() for :id", async () => {
-      const server = new Drash.Server({
-        resources: [NotesResource, UsersResource],
-      });
-      let request;
-      let response;
-      request = TestHelpers.mockRequest("/users/1");
-      response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(decoder.decode(response.body), {
-        user_id: "1",
-      });
-      request = TestHelpers.mockRequest("/users/1/");
-      response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(decoder.decode(response.body), {
-        user_id: "1",
-      });
-      request = TestHelpers.mockRequest("/notes/1557");
-      response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(
-        decoder.decode(response.body as ArrayBuffer),
-        { note_id: "1557" },
-      );
-      request = TestHelpers.mockRequest("/notes/1557/");
-      response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(
-        decoder.decode(response.body as ArrayBuffer),
-        { note_id: "1557" },
-      );
-    });
-
-    Rhum.testCase("getHeaderParam()", async () => {
-      const server = new Drash.Server({
-        resources: [GetHeaderParam],
-      });
-      const request = TestHelpers.mockRequest("/", "get", {
-        headers: {
-          id: 12345,
-        },
-      });
-      const response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(
-        decoder.decode(response.body as ArrayBuffer),
-        { header_param: "12345" },
-      );
-    });
-
-    Rhum.testCase("getUrlQueryParam()", async () => {
-      const server = new Drash.Server({
-        resources: [GetUrlQueryParam],
-      });
-      const request = TestHelpers.mockRequest("/?id=123459");
-      const response = await server.handleHttpRequest(request);
-      TestHelpers.assertResponseJsonEquals(
-        decoder.decode(response.body as ArrayBuffer),
-        { query_param: "123459" },
-      );
-    });
-
-    Rhum.testCase("response.redirect() with 301", async () => {
-      const server = new Drash.Server({
-        resources: [NotesResource],
-      });
-      let request;
-      let response;
-      request = TestHelpers.mockRequest("/notes/1234", "get", {
-        server: server,
-      });
-      response = await server.handleHttpRequest(request);
-      Rhum.asserts.assertEquals(response.status, 301);
-      Rhum.asserts.assertEquals(
-        response.headers!.get("location"),
-        "/notes/1667",
-      );
-    });
-
-    Rhum.testCase("response.redirect() with 302", async () => {
-      const server = new Drash.Server({
-        resources: [NotesResource],
-      });
-      let request;
-      let response;
-      request = TestHelpers.mockRequest("/notes/123", "get", {
-        server: server,
-      });
-      response = await server.handleHttpRequest(request);
-      Rhum.asserts.assertEquals(response.status, 302);
-      Rhum.asserts.assertEquals(
-        response.headers!.get("location"),
-        "/notes/1557",
-      );
-    });
-
-    Rhum.testCase(
-      "Throws an error when the response was not returned in the resource",
-      async () => {
-        const server = new Drash.Server({
-          resources: [InvalidReturningOfResponseResource],
-        });
-        let request = TestHelpers.mockRequest("/invalid/returning/of/response");
-        let response = await server.handleHttpRequest(request);
-        Rhum.asserts.assertEquals(response.status_code, 418);
-        request = TestHelpers.mockRequest(
-          "/invalid/returning/of/response",
-          "POST",
-        );
-        response = await server.handleHttpRequest(request);
-        Rhum.asserts.assertEquals(response.status_code, 418);
-      },
-    );
-  });
-
-  Rhum.testSuite("handleHttpRequestError()", () => {
-    Rhum.testCase("Returns the correct response", async () => {
-      const request = TestHelpers.mockRequest("/", "get");
-      const server = new Drash.Server({});
-      const error = new Drash.Errors.HttpError(404, "Some error message");
-      const response = await server.handleHttpRequestError(request, error);
-      Rhum.asserts.assertEquals(response.status, 404);
-      Rhum.asserts.assertEquals(
-        decoder.decode(response.body as ArrayBuffer),
-        '"Some error message"',
-      );
+  Rhum.testSuite("close()", () => {
+    Rhum.testCase("Closes the server", async () => {
+      const server = new Server({ port: 1234 });
+      await server.runHttp();
+      await Deno.connect({
+        hostname: server.options.hostname,
+        port: server.options.port
+      })
+      server.close();
+      assertThrowsAsync(async () => {await Deno.connect({
+        hostname: server.options.hostname,
+        port: server.options.port
+      })})
     });
   });
 
   Rhum.testSuite("run()", () => {
-    Rhum.testCase("Runs a server", async () => {
-      class Resource extends Drash.Resource {
-        static paths = ["/"];
-        public GET() {
-          this.response.body = "Hello world!";
-          return this.response;
-        }
-      }
-      const server = new Drash.Server({
-        resources: [Resource],
-      });
-      await server.run({
-        hostname: "localhost",
-        port: 1667,
-      });
-      const res = await fetch("http://localhost:1667");
-      const text = await res.text();
-      await server.close();
-      Rhum.asserts.assertEquals(res.status, 200);
-      Rhum.asserts.assertEquals(text, '"Hello world!"');
-    });
-  });
-
-  Rhum.testSuite("runTLS()", () => {
-    // TODO(ebebbington) TLS doesn't work with fetch atm. See: https://github.com/denoland/deno/issues/2301
-    //  and: https://github.com/denoland/deno/issues/1371. Might need to update the certs.
-    // Rhum.testCase("Runs a server", async  () => {
-    //   class Resource extends Drash.Resource {
-    //     static paths = ["/"];
-    //     public GET() {
-    //       this.response.body = "Hello world!";
-    //       return this.response;
-    //     }
-    //   }
-    //   const server = new Drash.Server({
-    //     resources: [Resource]
-    //   });
-    //   await server.runTLS({
-    //     hostname: "localhost",
-    //     port: 1667,
-    //     certFile: "./tests/integration/app_3002_https/server.crt",
-    //     keyFile: "./tests/integration/app_3002_https/server.key"
-    //   });
-    //   const res = await fetch("https://localhost:1667");
-    //   const text = await res.text();
-    //   await server.close();
-    //   Rhum.asserts.assertEquals(res.status, 200);
-    //   Rhum.asserts.assertEquals(text, "\"Hello world!\"")
-    // });
-  });
-
-  Rhum.testSuite("close()", () => {
-    Rhum.testCase("Closes the server", async () => {
-      const server = new Drash.Server({});
-      await server.run({
-        hostname: "localhost",
-        port: 1667,
-      });
-      const denoServerExists: boolean = !!server.deno_server;
-      Rhum.asserts.assert(denoServerExists);
-      server.close();
-      Rhum.asserts.assert(!server.deno_server);
-    });
-  });
-
-  Rhum.testSuite("isValidResponse()", () => {
-    Rhum.testCase("Should check that the response object is valid", () => {
-      const server = new Drash.Server({});
-      const request = new Drash.Request(TestHelpers.mockRequest("/hello"));
-      const isValidResponse = Reflect.get(server, "isValidResponse");
-      let response = new Drash.Response(
-        request,
-        {},
-      );
-      const resource = new HomeResource(
-        request,
-        response,
-        server,
-        ["/"],
-        {},
-      );
-      //Simulate user not returning properly inside their resource method
-      const possiblesInvalidResponse = [
-        "hello",
-        true,
-        1,
-        { name: "Ed" },
-        ["hello"],
-        null,
-        undefined,
-      ];
-      possiblesInvalidResponse.forEach((invalidRes) => {
-        Rhum.asserts.assertThrows(() => {
-          isValidResponse(request, invalidRes, resource);
-        });
-      });
-      const responseOutput: Drash.Interfaces.IResponseOutput = {
-        body: new Uint8Array(1),
-        headers: new Headers(),
-        status: 69420,
-        status_code: 418,
-        send: undefined,
-      };
-      response = new Drash.Response(
-        request,
-        {},
-      );
-      let isValid = isValidResponse(request, responseOutput, resource);
-      Rhum.asserts.assertEquals(isValid, true);
-      isValid = isValidResponse(request, response, resource);
-      Rhum.asserts.assertEquals(isValid, true);
-    });
-  });
+    Rhum.testCase("TODO", async () => {
+      
+    })
+  })
 });
 
 Rhum.run();

--- a/tests/unit/http/server_test.ts
+++ b/tests/unit/http/server_test.ts
@@ -2,24 +2,15 @@ import { Drash, Rhum, TestHelpers } from "../../deps.ts";
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 import { Server } from "../../../src/http/server.ts"
+import { DrashResource } from "../../../src/http/resource.ts"
 import { assertThrowsAsync } from "../../deps.ts"
 
 Rhum.testPlan("http/server_test.ts", () => {
-  Rhum.testSuite("constructor()", () => {
-    Rhum.testCase("Sets properties on the class correctly", () => {
-      const server = new Server({
-        port: 1234,
-      })
-      Rhum.asserts.assertEquals(server.options, {
-        // TODO
-      })
-    })
-  })
 
   Rhum.testSuite("address", () => {
     Rhum.testCase("Should correctly format the address", () => {
-      const server1 = new Server({ protocol: "https", hostname: "hosty" ,port: 1234 })
-      const server2 = new Server({ port: 1234 })
+      const server1 = new Server({ protocol: "https", hostname: "hosty" ,port: 1234, resources: [HomeResource] })
+      const server2 = new Server({ port: 1234, resources: [HomeResource], protocol: "http" })
       Rhum.asserts.assertEquals(server1.address, "https://hosty:1234")
       Rhum.asserts.assertEquals(server2.address, "http://localhost:1234")
     })
@@ -27,23 +18,80 @@ Rhum.testPlan("http/server_test.ts", () => {
 
   Rhum.testSuite("close()", () => {
     Rhum.testCase("Closes the server", async () => {
-      const server = new Server({ port: 1234 });
-      await server.runHttp();
+      const server = new Server({ port: 1234, resources: [HomeResource], protocol: "http" });
+      await server.run();
       await Deno.connect({
-        hostname: server.options.hostname,
-        port: server.options.port
+        hostname: "localhost",
+        port: 1234
       })
       server.close();
       assertThrowsAsync(async () => {await Deno.connect({
-        hostname: server.options.hostname,
-        port: server.options.port
+        hostname: "localhost",
+        port: 1234
       })})
     });
   });
 
   Rhum.testSuite("run()", () => {
-    Rhum.testCase("TODO", async () => {
-      
+    Rhum.testCase("Will listen correctly and send the proper response", async () => {
+      const server = new Server({
+        port: 1234,
+        protocol: "http",
+        resources: [HomeResource]
+      })
+      await server.run()
+      const res = await fetch("http://localhost:1234")
+      Rhum.asserts.assertEquals(await res.json(),
+        'Just the response form the home resource'
+      )
+      Rhum.asserts.assertEquals(res.status, 200)
+    })
+    Rhum.testCase("Will throw a 404 if no resource found matching the uri", async () => {
+      const server = new Server({
+        port: 1234,
+        protocol: "http",
+        resources: [HomeResource]
+      })
+      await server.run()
+      const res = await fetch("http://localhost:1234/dont/exist")
+      Rhum.asserts.assertEquals(await res.json(),
+        'Just the response form the home resource'
+      )
+      Rhum.asserts.assertEquals(res.status, 404)
+    })
+    Rhum.testCase("Will throw a 405 if the req method isnt found on the resource", async () => {
+      const server = new Server({
+        port: 1234,
+        protocol: "http",
+        resources: [HomeResource]
+      })
+      await server.run()
+      const res = await fetch("http://localhost:1234", {
+        method: "OPTIONS"
+      })
+      Rhum.asserts.assertEquals(await res.json(),
+        'Just the response form the home resource'
+      )
+      Rhum.asserts.assertEquals(res.status, 405)
+    })
+    Rhum.testCase("Will parse the body if it exists on the request", async () => {
+      const server = new Server({
+        port: 1234,
+        protocol: "http",
+        resources: [HomeResource]
+      })
+      await server.run()
+      const res = await fetch("http://localhost:1234", {
+        method: "POST",
+        headers: {
+          'Content-Type': "application/json"
+        },
+        body: JSON.stringify({ name: "Drash" })
+      })
+      Rhum.asserts.assertEquals(await res.json(),
+        'The resource should send the same body back to us'
+      )
+      Rhum.asserts.assertEquals(res.status, 200)
     })
   })
 });
@@ -54,22 +102,21 @@ Rhum.run();
 // FILE MARKER - DATA //////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-class HomeResource extends Drash.Resource {
-  static paths = ["/", "/:some_param"];
+class HomeResource extends DrashResource {
+  static paths = ["/"];
   public GET() {
-    const someParam = this.request.getPathParam("some_param");
-    if (someParam) {
-      this.response.body = { body: someParam };
-      return this.response;
-    }
-    this.response.body = { body: "got" };
+    this.response.body = JSON.stringify({
+      success: true
+    });
     return this.response;
   }
   public POST() {
-    this.response.body = { body: this.request.getBodyParam("body_param") };
+    this.response.body = this.request.body;
     return this.response;
   }
 }
+
+// TODO Move the below classes into integration tests
 
 class UsersResource extends Drash.Resource {
   static paths = ["/users/:id"];


### PR DESCRIPTION
Started adding tests
Uses es private methods where possible for server because i dont believe a user would need to access any of the methods accept for run
Only expose a single `run` method to the user, where the constructor sets the protocol and the run method determines if to run a http or https server based on that

bye bye sleepy time